### PR TITLE
ci: add Jenkinsfile that runs lint and test targets

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,35 @@
+pipeline {
+  agent {
+    label 'linux'
+  }
+
+  options {
+    timestamps()
+    buildDiscarder(logRotator(
+      numToKeepStr: '10',
+      daysToKeepStr: '30',
+    ))
+  }
+
+  environment {
+    GOPATH = "${env.HOME}/go"
+    PATH   = "${env.PATH}:${env.GOPATH}/bin"
+  }
+
+  stages {
+    stage('Deps') {
+      steps { sh 'make deps' }
+    }
+
+    stage('Lint') {
+      steps { sh 'make lint' }
+    }
+
+    stage('Test') {
+      steps { sh 'make test' }
+    }
+  }
+  post {
+    always { cleanWs() }
+  }
+}

--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,17 @@
 
 all: build
 
+deps: lint-install
+
 build:
 	go build -o build/waku waku.go
+
+lint-install:
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | \
+		bash -s -- -b $(shell go env GOPATH)/bin v1.41.1
 
 lint:
 	@echo "lint"
 	@golangci-lint --exclude=SA1019 run ./... --deadline=5m
 test:
 	go test -v -failfast ./...
-


### PR DESCRIPTION
This adds a simple `Jenkinsfile` that runs `make lint` and `make test`.
Had to also add a `deps` target that runs `lint-install` to install missing `golangci-lint`.

Jobs folder: https://ci.status.im/job/go-waku/
Resolves: https://github.com/status-im/go-waku/issues/11