### PR TITLE
feat: rendezvous pt1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/viper v1.7.1
+	github.com/status-im/go-libp2p-rendezvous v0.0.0-20210928230014-94a02b1432a3 // indirect
 	github.com/status-im/go-wakurelay-pubsub v0.4.3-0.20210729162817-adc68830282a
 	github.com/stretchr/testify v1.7.0
 	go.opencensus.io v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -238,6 +238,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
+github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
+github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0/go.mod h1:E/TSTwGwJL78qG/PmXZO1EjYhfJinVAhrmmHX6Z8B9k=
 github.com/golang/geo v0.0.0-20190916061304-5b978397cfec/go.mod h1:QZ0nwyI2jOfgRAoBvP+ab5aRr7c9x7lhGEJrKvBwjWI=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -459,6 +461,7 @@ github.com/kami-zh/go-capturer v0.0.0-20171211120116-e492ea43421d/go.mod h1:P2vi
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
+github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/klauspost/compress v1.4.0/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
@@ -942,6 +945,12 @@ github.com/spf13/viper v1.7.1/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5q
 github.com/src-d/envconfig v1.0.0/go.mod h1:Q9YQZ7BKITldTBnoxsE5gOeB5y66RyPXeue/R4aaNBc=
 github.com/status-im/go-ethereum v1.10.4-status.2 h1:uvcD2U7skYqPQviARFb4w3wZyFSYLs/pfVrJaRSDcCA=
 github.com/status-im/go-ethereum v1.10.4-status.2/go.mod h1:GvIhpdCOgMHI6i5xVPEZOrv/qSMeOFHbZh77AoyZUoE=
+github.com/status-im/go-libp2p-rendezvous v0.0.0-20210928195017-4397dd0f844d h1:cJkS8VzW0jwOne1ipKiUCjMLbMQU7Xa7XPJCMrjZCNU=
+github.com/status-im/go-libp2p-rendezvous v0.0.0-20210928195017-4397dd0f844d/go.mod h1:up+uGvIr4JbhszgZB4fLcFoc0xbihgv1M885ZQrgtIs=
+github.com/status-im/go-libp2p-rendezvous v0.0.0-20210928205005-be9b1a0035bf h1:hhkIKjPCMuDd1T5h0DPc4dS2HUc1tzkMw1ReWj7stnY=
+github.com/status-im/go-libp2p-rendezvous v0.0.0-20210928205005-be9b1a0035bf/go.mod h1:up+uGvIr4JbhszgZB4fLcFoc0xbihgv1M885ZQrgtIs=
+github.com/status-im/go-libp2p-rendezvous v0.0.0-20210928230014-94a02b1432a3 h1:C6Ed5GA9wlvNOZeLi16hMVpEXLb+4AhGSDx/ZljtWbs=
+github.com/status-im/go-libp2p-rendezvous v0.0.0-20210928230014-94a02b1432a3/go.mod h1:up+uGvIr4JbhszgZB4fLcFoc0xbihgv1M885ZQrgtIs=
 github.com/status-im/go-wakurelay-pubsub v0.4.3-0.20210729162817-adc68830282a h1:eCna/q/PuZVqtmOMBqytw9yzZwMNKpao4au0OJDvesI=
 github.com/status-im/go-wakurelay-pubsub v0.4.3-0.20210729162817-adc68830282a/go.mod h1:LSCVYR7mnBBsxVJghrGpQ3yJAAATEe6XeQQqGCZhwrE=
 github.com/status-im/keycard-go v0.0.0-20190316090335-8537d3370df4/go.mod h1:RZLeN1LMWmRsyYjvAu+I6Dm9QmlDaIIt+Y+4Kd7Tp+Q=
@@ -1280,9 +1289,11 @@ golang.org/x/tools v0.0.0-20200501065659-ab2804fb9c9d/go.mod h1:EkVYQZoAsY45+roY
 golang.org/x/tools v0.0.0-20200512131952-2bc93b1c0c88/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200515010526-7d3b6ebf133d/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200618134242-20370b0cb4b2/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
+golang.org/x/tools v0.0.0-20200619180055-7c47624df98f/go.mod h1:EkVYQZoAsY45+roYkvgYkIh4xh/qjgUK9TdY2XT94GE=
 golang.org/x/tools v0.0.0-20200729194436-6467de6f59a7/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200804011535-6c149bb5ef0d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/waku/node.go
+++ b/waku/node.go
@@ -95,9 +95,6 @@ var rootCmd = &cobra.Command{
 		prvKey, err := crypto.HexToECDSA(key)
 		checkError(err, "error converting key into valid ecdsa key")
 
-		// TODO: this ENR record might be necessary later for DNS discovery
-		// enr := enode.NewV4(&prvKey.PublicKey, hostAddr.IP, hostAddr.Port, 0)
-
 		if dbPath == "" && useDB {
 			checkError(errors.New("dbpath can't be null"), "")
 		}

--- a/waku/node.go
+++ b/waku/node.go
@@ -95,6 +95,9 @@ var rootCmd = &cobra.Command{
 		prvKey, err := crypto.HexToECDSA(key)
 		checkError(err, "error converting key into valid ecdsa key")
 
+		// TODO: this ENR record might be necessary later for DNS discovery
+		// enr := enode.NewV4(&prvKey.PublicKey, hostAddr.IP, hostAddr.Port, 0)
+
 		if dbPath == "" && useDB {
 			checkError(errors.New("dbpath can't be null"), "")
 		}
@@ -198,13 +201,14 @@ var rootCmd = &cobra.Command{
 					ctx, cancel := context.WithTimeout(ctx, time.Duration(3)*time.Second)
 					defer cancel()
 					err = wakuNode.DialPeer(ctx, node)
-					checkError(err, "error dialing peer")
+					if err != nil {
+						log.Error("error dialing peer ", err)
+					}
 				}(n)
 			}
 		}
 
 		if enableDnsDiscovery {
-
 			for _, addr := range wakuNode.ListenAddresses() {
 				ip, _ := addr.ValueForProtocol(multiaddr.P_IP4)
 				enr := enode.NewV4(&prvKey.PublicKey, net.ParseIP(ip), hostAddr.Port, 0)

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -8,6 +8,7 @@ import (
 	"github.com/libp2p/go-libp2p"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	"github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/libp2p/go-libp2p-core/peer"
 	ma "github.com/multiformats/go-multiaddr"
 	manet "github.com/multiformats/go-multiaddr-net"
 	"github.com/status-im/go-waku/waku/v2/protocol/store"
@@ -31,6 +32,11 @@ type WakuNodeParameters struct {
 	storeMsgs    bool
 	store        *store.WakuStore
 	// filter      *filter.WakuFilter
+
+	enableRendezvous       bool
+	enableRendezvousServer bool
+	rendezvousPeers        []peer.ID
+	rendezvousOpts         []wakurelay.DiscoverOpt
 
 	keepAliveInterval time.Duration
 
@@ -92,6 +98,22 @@ func WithWakuRelay(opts ...wakurelay.Option) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableRelay = true
 		params.wOpts = opts
+		return nil
+	}
+}
+
+func WithRendezvous(peers []peer.ID, discoverOpts ...wakurelay.DiscoverOpt) WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.enableRendezvous = true
+		params.rendezvousPeers = peers
+		params.rendezvousOpts = discoverOpts
+		return nil
+	}
+}
+
+func WithRendezvousServer() WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.enableRendezvousServer = true
 		return nil
 	}
 }


### PR DESCRIPTION
Adds rendezvous capabilities to go-waku:

You can create a rendezvous server with the `--rendezvous-server` flag
```
make
./build/waku --rendezvous-server --nodekey 1122334455667788990011223344556677889900112233445566778899001122
```

Then, any node that wants to connect to this rendezvous node, needs to add it as a static node, use the flag `--rendezvous` and the flag `--rendezvous-nodes` with the peerId of the rendezvous node:
```
./build/waku --port 0 --rendezvous --staticnodes /ip4/127.0.0.1/tcp/9000/p2p/16Uiu2HAmMGhfSTUzKbsjMWxc6T1X4wiTWSF1bEWSLjAukCm7KiHV --rendezvous-nodes 16Uiu2HAmMGhfSTUzKbsjMWxc6T1X4wiTWSF1bEWSLjAukCm7KiHV --dbpath "./somedatabase.db"
```