### PR TITLE
refactor: store and lightpush

### DIFF
--- a/examples/chat2/main.go
+++ b/examples/chat2/main.go
@@ -205,7 +205,7 @@ func main() {
 		q := store.Query{
 			ContentTopics: []string{*contentTopicFlag},
 		}
-		response, err := wakuNode.Query(tCtx, q,
+		response, err := wakuNode.Store().Query(tCtx, q,
 			store.WithAutomaticRequestId(),
 			store.WithPeer(*storeNodeId),
 			store.WithPaging(true, 0))

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -33,10 +33,10 @@ type WakuNodeParameters struct {
 	isFilterFullNode bool
 	wOpts            []pubsub.Option
 
-	enableStore  bool
-	shouldResume bool
-	storeMsgs    bool
-	store        *store.WakuStore
+	enableStore     bool
+	shouldResume    bool
+	storeMsgs       bool
+	messageProvider store.MessageProvider
 
 	enableRendezvous       bool
 	enableRendezvousServer bool
@@ -166,7 +166,6 @@ func WithWakuStore(shouldStoreMessages bool, shouldResume bool) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
 		params.enableStore = true
 		params.storeMsgs = shouldStoreMessages
-		params.store = store.NewWakuStore(shouldStoreMessages, nil)
 		params.shouldResume = shouldResume
 		return nil
 	}
@@ -176,11 +175,7 @@ func WithWakuStore(shouldStoreMessages bool, shouldResume bool) WakuNodeOption {
 // used to store and retrieve persisted messages
 func WithMessageProvider(s store.MessageProvider) WakuNodeOption {
 	return func(params *WakuNodeParameters) error {
-		if params.store != nil {
-			params.store.SetMsgProvider(s)
-		} else {
-			params.store = store.NewWakuStore(true, s)
-		}
+		params.messageProvider = s
 		return nil
 	}
 }

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -17,6 +17,8 @@ import (
 	"github.com/status-im/go-waku/waku/v2/protocol/pb"
 	"github.com/status-im/go-waku/waku/v2/protocol/relay"
 	utils "github.com/status-im/go-waku/waku/v2/utils"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 )
 
 var log = logging.Logger("waku_lightpush")
@@ -216,4 +218,10 @@ func (wakuLP *WakuLightPush) Request(ctx context.Context, req *pb.PushRequest, o
 
 func (w *WakuLightPush) Stop() {
 	w.h.RemoveStreamHandler(LightPushID_v20beta1)
+}
+
+func recordErrorMetric(ctx context.Context, tagType string) {
+	if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(tag.Key(metrics.ErrorType), tagType)}, metrics.LightpushErrors.M(1)); err != nil {
+		log.Error("failed to record with tags", err)
+	}
 }

--- a/waku/v2/protocol/lightpush/waku_lightpush.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush.go
@@ -17,8 +17,6 @@ import (
 	"github.com/status-im/go-waku/waku/v2/protocol/pb"
 	"github.com/status-im/go-waku/waku/v2/protocol/relay"
 	utils "github.com/status-im/go-waku/waku/v2/utils"
-	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 )
 
 var log = logging.Logger("waku_lightpush")
@@ -218,10 +216,4 @@ func (wakuLP *WakuLightPush) Request(ctx context.Context, req *pb.PushRequest, o
 
 func (w *WakuLightPush) Stop() {
 	w.h.RemoveStreamHandler(LightPushID_v20beta1)
-}
-
-func recordErrorMetric(ctx context.Context, tagType string) {
-	if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(tag.Key(metrics.ErrorType), tagType)}, metrics.LightpushErrors.M(1)); err != nil {
-		log.Error("failed to record with tags", err)
-	}
 }

--- a/waku/v2/protocol/store/waku_resume_test.go
+++ b/waku/v2/protocol/store/waku_resume_test.go
@@ -20,7 +20,7 @@ func TestFindLastSeenMessage(t *testing.T) {
 	msg4 := tests.CreateWakuMessage("4", 4)
 	msg5 := tests.CreateWakuMessage("5", 5)
 
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 	s.storeMessage("test", msg1)
 	s.storeMessage("test", msg3)
 	s.storeMessage("test", msg5)
@@ -37,7 +37,7 @@ func TestResume(t *testing.T) {
 	host1, err := libp2p.New(ctx, libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(true, nil)
+	s1 := NewWakuStore(nil)
 	s1.Start(ctx, host1)
 	defer s1.Stop()
 
@@ -54,7 +54,7 @@ func TestResume(t *testing.T) {
 	host2, err := libp2p.New(ctx, libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s2 := NewWakuStore(false, nil)
+	s2 := NewWakuStore(nil)
 	s2.Start(ctx, host2)
 	defer s2.Stop()
 
@@ -86,7 +86,7 @@ func TestResumeWithListOfPeers(t *testing.T) {
 	host1, err := libp2p.New(ctx, libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(true, nil)
+	s1 := NewWakuStore(nil)
 	s1.Start(ctx, host1)
 	defer s1.Stop()
 
@@ -97,7 +97,7 @@ func TestResumeWithListOfPeers(t *testing.T) {
 	host2, err := libp2p.New(ctx, libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s2 := NewWakuStore(false, nil)
+	s2 := NewWakuStore(nil)
 	s2.Start(ctx, host2)
 	defer s2.Stop()
 
@@ -119,7 +119,7 @@ func TestResumeWithoutSpecifyingPeer(t *testing.T) {
 	host1, err := libp2p.New(ctx, libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(true, nil)
+	s1 := NewWakuStore(nil)
 	s1.Start(ctx, host1)
 	defer s1.Stop()
 
@@ -130,7 +130,7 @@ func TestResumeWithoutSpecifyingPeer(t *testing.T) {
 	host2, err := libp2p.New(ctx, libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s2 := NewWakuStore(false, nil)
+	s2 := NewWakuStore(nil)
 	s2.Start(ctx, host2)
 	defer s2.Stop()
 

--- a/waku/v2/protocol/store/waku_store.go
+++ b/waku/v2/protocol/store/waku_store.go
@@ -17,6 +17,8 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	libp2pProtocol "github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/libp2p/go-msgio/protoio"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	"github.com/status-im/go-waku/waku/persistence"
 	"github.com/status-im/go-waku/waku/v2/metrics"
@@ -697,4 +699,16 @@ func (store *WakuStore) Resume(ctx context.Context, pubsubTopic string, peerList
 
 func (w *WakuStore) Stop() {
 	w.h.RemoveStreamHandler(StoreID_v20beta3)
+}
+
+func recordMessageMetrics(ctx context.Context, tagType string, len int) {
+	if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(metrics.KeyType, tagType)}, metrics.StoreMessages.M(int64(len))); err != nil {
+		log.Error("failed to record with tags", err)
+	}
+}
+
+func recordErrorMetric(ctx context.Context, tagType string) {
+	if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(metrics.ErrorType, tagType)}, metrics.StoreErrors.M(1)); err != nil {
+		log.Error("failed to record with tags", err)
+	}
 }

--- a/waku/v2/protocol/store/waku_store.go
+++ b/waku/v2/protocol/store/waku_store.go
@@ -17,8 +17,6 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	libp2pProtocol "github.com/libp2p/go-libp2p-core/protocol"
 	"github.com/libp2p/go-msgio/protoio"
-	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 
 	"github.com/status-im/go-waku/waku/persistence"
 	"github.com/status-im/go-waku/waku/v2/metrics"
@@ -699,16 +697,4 @@ func (store *WakuStore) Resume(ctx context.Context, pubsubTopic string, peerList
 
 func (w *WakuStore) Stop() {
 	w.h.RemoveStreamHandler(StoreID_v20beta3)
-}
-
-func recordMessageMetrics(ctx context.Context, tagType string, len int) {
-	if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(metrics.KeyType, tagType)}, metrics.StoreMessages.M(int64(len))); err != nil {
-		log.Error("failed to record with tags", err)
-	}
-}
-
-func recordErrorMetric(ctx context.Context, tagType string) {
-	if err := stats.RecordWithTags(ctx, []tag.Mutator{tag.Insert(metrics.ErrorType, tagType)}, metrics.StoreErrors.M(1)); err != nil {
-		log.Error("failed to record with tags", err)
-	}
 }

--- a/waku/v2/protocol/store/waku_store_persistence_test.go
+++ b/waku/v2/protocol/store/waku_store_persistence_test.go
@@ -23,7 +23,7 @@ func TestStorePersistence(t *testing.T) {
 	dbStore, err := persistence.NewDBStore(persistence.WithDB(db))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(true, dbStore)
+	s1 := NewWakuStore(dbStore)
 	s1.fetchDBRecords(ctx)
 	require.Len(t, s1.messages, 0)
 
@@ -38,7 +38,7 @@ func TestStorePersistence(t *testing.T) {
 
 	s1.storeMessage(defaultPubSubTopic, msg)
 
-	s2 := NewWakuStore(true, dbStore)
+	s2 := NewWakuStore(dbStore)
 	s2.fetchDBRecords(ctx)
 	require.Len(t, s2.messages, 1)
 	require.Equal(t, msg, s2.messages[0].msg)

--- a/waku/v2/protocol/store/waku_store_protocol_test.go
+++ b/waku/v2/protocol/store/waku_store_protocol_test.go
@@ -20,7 +20,7 @@ func TestWakuStoreProtocolQuery(t *testing.T) {
 	host1, err := libp2p.New(ctx, libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(true, nil)
+	s1 := NewWakuStore(nil)
 	s1.Start(ctx, host1)
 	defer s1.Stop()
 
@@ -39,7 +39,7 @@ func TestWakuStoreProtocolQuery(t *testing.T) {
 	// Simulate a message has been received via relay protocol
 	s1.MsgC <- protocol.NewEnvelope(msg, pubsubTopic1)
 
-	s2 := NewWakuStore(false, nil)
+	s2 := NewWakuStore(nil)
 	s2.Start(ctx, host2)
 	defer s2.Stop()
 
@@ -66,7 +66,7 @@ func TestWakuStoreProtocolNext(t *testing.T) {
 	host1, err := libp2p.New(ctx, libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(true, nil)
+	s1 := NewWakuStore(nil)
 	s1.Start(ctx, host1)
 	defer s1.Stop()
 
@@ -92,7 +92,7 @@ func TestWakuStoreProtocolNext(t *testing.T) {
 	err = host2.Peerstore().AddProtocols(host1.ID(), string(StoreID_v20beta3))
 	require.NoError(t, err)
 
-	s2 := NewWakuStore(false, nil)
+	s2 := NewWakuStore(nil)
 	s2.Start(ctx, host2)
 	defer s2.Stop()
 

--- a/waku/v2/protocol/store/waku_store_query_test.go
+++ b/waku/v2/protocol/store/waku_store_query_test.go
@@ -16,7 +16,7 @@ func TestStoreQuery(t *testing.T) {
 	msg1 := tests.CreateWakuMessage(defaultContentTopic, utils.GetUnixEpoch())
 	msg2 := tests.CreateWakuMessage("2", utils.GetUnixEpoch())
 
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 	s.storeMessage(defaultPubSubTopic, msg1)
 	s.storeMessage(defaultPubSubTopic, msg2)
 
@@ -42,7 +42,7 @@ func TestStoreQueryMultipleContentFilters(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, utils.GetUnixEpoch())
 	msg3 := tests.CreateWakuMessage(topic3, utils.GetUnixEpoch())
 
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 
 	s.storeMessage(defaultPubSubTopic, msg1)
 	s.storeMessage(defaultPubSubTopic, msg2)
@@ -76,7 +76,7 @@ func TestStoreQueryPubsubTopicFilter(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, utils.GetUnixEpoch())
 	msg3 := tests.CreateWakuMessage(topic3, utils.GetUnixEpoch())
 
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 	s.storeMessage(pubsubTopic1, msg1)
 	s.storeMessage(pubsubTopic2, msg2)
 	s.storeMessage(pubsubTopic2, msg3)
@@ -108,7 +108,7 @@ func TestStoreQueryPubsubTopicNoMatch(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, utils.GetUnixEpoch())
 	msg3 := tests.CreateWakuMessage(topic3, utils.GetUnixEpoch())
 
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 	s.storeMessage(pubsubTopic2, msg1)
 	s.storeMessage(pubsubTopic2, msg2)
 	s.storeMessage(pubsubTopic2, msg3)
@@ -130,7 +130,7 @@ func TestStoreQueryPubsubTopicAllMessages(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, utils.GetUnixEpoch())
 	msg3 := tests.CreateWakuMessage(topic3, utils.GetUnixEpoch())
 
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 	s.storeMessage(pubsubTopic1, msg1)
 	s.storeMessage(pubsubTopic1, msg2)
 	s.storeMessage(pubsubTopic1, msg3)
@@ -149,7 +149,7 @@ func TestStoreQueryForwardPagination(t *testing.T) {
 	topic1 := "1"
 	pubsubTopic1 := "topic1"
 
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 	for i := 0; i < 10; i++ {
 		msg := tests.CreateWakuMessage(topic1, utils.GetUnixEpoch())
 		msg.Payload = []byte{byte(i)}
@@ -173,7 +173,7 @@ func TestStoreQueryBackwardPagination(t *testing.T) {
 	topic1 := "1"
 	pubsubTopic1 := "topic1"
 
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 	for i := 0; i < 10; i++ {
 		msg := &pb.WakuMessage{
 			Payload:      []byte{byte(i)},
@@ -199,7 +199,7 @@ func TestStoreQueryBackwardPagination(t *testing.T) {
 }
 
 func TestTemporalHistoryQueries(t *testing.T) {
-	s := NewWakuStore(true, nil)
+	s := NewWakuStore(nil)
 
 	var messages []*pb.WakuMessage
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
To reduce the size of wakunode2.go and stop it from becoming a god object. The proper way to consume those protocols functionality will be like this:
```go
node, _ = wakunode.New()

// Lightpush
node.LightPush().Publish(...)

// Store
node.Store().Query(...)
node.Store().Resume(...)
```
In a separate PR I'll do similar changes to Relay and Filter protocols