### PR TITLE
feat: implement rcp relay get messages

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -336,6 +336,10 @@ func (w *WakuNode) DiscV5() *discv5.DiscoveryV5 {
 	return w.discoveryV5
 }
 
+func (w *WakuNode) Broadcaster() v2.Broadcaster {
+	return w.bcaster
+}
+
 func (w *WakuNode) mountRelay(opts ...pubsub.Option) error {
 	var err error
 	w.relay, err = relay.NewWakuRelay(w.ctx, w.host, w.bcaster, opts...)

--- a/waku/v2/rpc/relay_test.go
+++ b/waku/v2/rpc/relay_test.go
@@ -2,9 +2,13 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/multiformats/go-multiaddr"
 	"github.com/status-im/go-waku/waku/v2/node"
+	"github.com/status-im/go-waku/waku/v2/protocol/pb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -14,7 +18,7 @@ func makeRelayService(t *testing.T) *RelayService {
 	require.NoError(t, err)
 	err = n.Start()
 	require.NoError(t, err)
-	return &RelayService{n}
+	return NewRelayService(n)
 }
 
 func TestPostV1Message(t *testing.T) {
@@ -52,4 +56,72 @@ func TestRelaySubscription(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.True(t, reply.Success)
+}
+
+func TestRelayGetV1Messages(t *testing.T) {
+	serviceA := makeRelayService(t)
+	var reply SuccessReply
+
+	serviceB := makeRelayService(t)
+	go serviceB.Start()
+	defer serviceB.Stop()
+
+	hostInfo, err := multiaddr.NewMultiaddr(fmt.Sprintf("/p2p/%s", serviceB.node.Host().ID().Pretty()))
+	require.NoError(t, err)
+
+	var addr multiaddr.Multiaddr
+	for _, a := range serviceB.node.Host().Addrs() {
+		addr = a.Encapsulate(hostInfo)
+		break
+	}
+	err = serviceA.node.DialPeerWithMultiAddress(context.Background(), addr)
+	require.NoError(t, err)
+
+	// Wait for the dial to complete
+	time.Sleep(1 * time.Second)
+
+	args := &TopicsArgs{Topics: []string{"test"}}
+	err = serviceB.PostV1Subscription(
+		makeRequest(t),
+		args,
+		&reply,
+	)
+	require.NoError(t, err)
+	require.True(t, reply.Success)
+
+	// Wait for the subscription to be started
+	time.Sleep(1 * time.Second)
+
+	err = serviceA.PostV1Message(
+		makeRequest(t),
+		&RelayMessageArgs{
+			Topic: "test",
+			Message: pb.WakuMessage{
+				Payload: []byte("test"),
+			},
+		},
+		&reply,
+	)
+	require.NoError(t, err)
+	require.True(t, reply.Success)
+
+	// Wait for the message to be received
+	time.Sleep(1 * time.Second)
+
+	var messagesReply MessagesReply
+	err = serviceB.GetV1Messages(
+		makeRequest(t),
+		&TopicArgs{"test"},
+		&messagesReply,
+	)
+	require.NoError(t, err)
+	require.Len(t, messagesReply.Messages, 1)
+
+	err = serviceB.GetV1Messages(
+		makeRequest(t),
+		&TopicArgs{"test"},
+		&messagesReply,
+	)
+	require.NoError(t, err)
+	require.Len(t, messagesReply.Messages, 0)
 }

--- a/waku/v2/rpc/store_test.go
+++ b/waku/v2/rpc/store_test.go
@@ -17,7 +17,7 @@ func makeStoreService(t *testing.T) *StoreService {
 	return &StoreService{n}
 }
 
-func TestGetV1Message(t *testing.T) {
+func TestStoreGetV1Messages(t *testing.T) {
 	var reply StoreMessagesReply
 
 	s := makeStoreService(t)


### PR DESCRIPTION
The rpc service subscribe to the messages as per the specs here:
https://rfc.vac.dev/spec/16/#get_waku_v2_relay_v1_messages

Let me know if you have a better idea/place on how to implement this. I hesitate to make the relay itself message aware but I feel it is out of his responsabilities. WDYT