### PR TITLE
Create pluggable store

### DIFF
--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -74,6 +74,8 @@ type WakuNodeParameters struct {
 	enableLightPush bool
 
 	connStatusC chan ConnStatus
+
+	storeFactory storeFactory
 }
 
 type WakuNodeOption func(*WakuNodeParameters) error
@@ -241,6 +243,14 @@ func WithWakuStore(shouldStoreMessages bool, shouldResume bool) WakuNodeOption {
 		params.enableStore = true
 		params.storeMsgs = shouldStoreMessages
 		params.shouldResume = shouldResume
+		return nil
+	}
+}
+
+func WithWakuStoreFactory(factory storeFactory) WakuNodeOption {
+	return func(params *WakuNodeParameters) error {
+		params.storeFactory = factory
+
 		return nil
 	}
 }

--- a/waku/v2/node/wakuoptions_test.go
+++ b/waku/v2/node/wakuoptions_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/multiformats/go-multiaddr"
 	rendezvous "github.com/status-im/go-waku-rendezvous"
 	"github.com/status-im/go-waku/tests"
+	"github.com/status-im/go-waku/waku/v2/protocol/store"
 	"github.com/stretchr/testify/require"
 )
 
@@ -28,6 +29,10 @@ func TestWakuOptions(t *testing.T) {
 
 	advertiseAddr, _ := net.ResolveTCPAddr("tcp", "0.0.0.0:0")
 
+	storeFactory := func(w *WakuNode) store.Store {
+		return store.NewWakuStore(w.host, w.swap, w.opts.messageProvider, w.opts.maxMessages, w.opts.maxDuration, w.log)
+	}
+
 	options := []WakuNodeOption{
 		WithHostAddress(hostAddr),
 		WithAdvertiseAddress(advertiseAddr, false, 4000),
@@ -45,6 +50,7 @@ func TestWakuOptions(t *testing.T) {
 		WithLightPush(),
 		WithKeepAlive(time.Hour),
 		WithConnectionStatusChannel(connStatusChan),
+		WithWakuStoreFactory(storeFactory),
 	}
 
 	params := new(WakuNodeParameters)

--- a/waku/v2/protocol/store/waku_store.go
+++ b/waku/v2/protocol/store/waku_store.go
@@ -240,6 +240,15 @@ type WakuStore struct {
 	swap         *swap.WakuSwap
 }
 
+type Store interface {
+	Start(ctx context.Context)
+	Query(ctx context.Context, query Query, opts ...HistoryRequestOption) (*Result, error)
+	Next(ctx context.Context, r *Result) (*Result, error)
+	Resume(ctx context.Context, pubsubTopic string, peerList []peer.ID) (int, error)
+	MessageChannel() chan *protocol.Envelope
+	Stop()
+}
+
 // NewWakuStore creates a WakuStore using an specific MessageProvider for storing the messages
 func NewWakuStore(host host.Host, swap *swap.WakuSwap, p MessageProvider, maxNumberOfMessages int, maxRetentionDuration time.Duration, log *zap.SugaredLogger) *WakuStore {
 	wakuStore := new(WakuStore)
@@ -773,6 +782,10 @@ func (store *WakuStore) Resume(ctx context.Context, pubsubTopic string, peerList
 	store.log.Info("Retrieved messages since the last online time: ", len(messages))
 
 	return msgCount, nil
+}
+
+func (store *WakuStore) MessageChannel() chan *protocol.Envelope {
+	return store.MsgC
 }
 
 // TODO: queryWithAccounting


### PR DESCRIPTION
## Problem
The current `WakuNode` implementation references the store as a concrete struct type, rather than an interface. This makes it difficult to replace with an alternative store implementation.

Since the store is initialized inside the the `Start()` function of the `WakuNode`, it is even more difficult to replace. While there is a `MessageProvider` interface that can be replaced, this assumes that a store implementation will want to keep a full list of all messages in memory. That drastically limits the capacity of the store.

## Solution
- Create a `Store` interface type that can be used on the `WakuNode` struct, representing the public methods of the store.
- Introduce the concept of a `storeFactory`, which is a function receiving a `WakuNode` instance and returning a `Store` interface.
- Create a default `storeFactory` that replicates the existing store creation behaviour
- Create a new parameter allowing the default `storeFactory` to be replaced.