### PR TITLE
Push subscriptions in parallel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,5 +31,6 @@ require (
 	github.com/urfave/cli/v2 v2.4.0
 	go.opencensus.io v0.23.0
 	go.uber.org/zap v1.21.0
+	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1224,6 +1224,8 @@ golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
+golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/waku/v2/protocol/filter/waku_filter.go
+++ b/waku/v2/protocol/filter/waku_filter.go
@@ -188,7 +188,7 @@ func (wf *WakuFilter) FilterListener() {
 	handle := func(envelope *protocol.Envelope) error { // async
 		msg := envelope.Message()
 		topic := envelope.PubsubTopic()
-		g, _ := errgroup.WithContext(context.Background())
+		g := new(errgroup.Group)
 		// Each subscriber is a light node that earlier on invoked
 		// a FilterRequest on this node
 		for subscriber := range wf.subscribers.Items() {


### PR DESCRIPTION
## Summary
When pushing messages to subscribers, we want to ensure that a single slow/unavailable subscriber cannot block the entire filter listener. This creates one goroutine per subscriber to ensure speedy delivery.

While the existing implementation will eventually remove failing subscribers, even a single subscriber that is timing out or unavailable can  disrupt all further subscriptions as the handler is returned on error.