### PR TITLE
Structured logging followup

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -8,9 +8,11 @@
 package logging
 
 import (
+	"net"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/multiformats/go-multiaddr"
 	"github.com/status-im/go-waku/waku/v2/protocol/pb"
@@ -109,4 +111,19 @@ func HexBytes(key string, bytes []byte) zap.Field {
 
 func (bytes hexBytes) String() string {
 	return hexutil.Encode(bytes)
+}
+
+// ENode creates a field for ENR node.
+func ENode(key string, node *enode.Node) zap.Field {
+	return zap.Stringer(key, node)
+}
+
+// TCPAddr creates a field for TCP v4/v6 address and port
+func TCPAddr(key string, ip net.IP, port int) zap.Field {
+	return zap.Stringer(key, &net.TCPAddr{IP: ip, Port: port})
+}
+
+// UDPAddr creates a field for UDP v4/v6 address and port
+func UDPAddr(key string, ip net.IP, port int) zap.Field {
+	return zap.Stringer(key, &net.UDPAddr{IP: ip, Port: port})
 }

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -9,24 +9,14 @@ import (
 	"net"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/multiformats/go-multiaddr"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/status-im/go-waku/waku/v2/protocol/pb"
-	"go.uber.org/zap"
 )
-
-var log *zap.SugaredLogger = nil
-
-func Logger() *zap.SugaredLogger {
-	if log == nil {
-		l, _ := zap.NewDevelopment()
-		log = l.Sugar()
-	}
-	return log
-}
 
 // GetHostAddress returns the first listen address used by a host
 func GetHostAddress(ha host.Host) ma.Multiaddr {

--- a/waku/metrics/http_test.go
+++ b/waku/metrics/http_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestStartAndStopMetricsServer(t *testing.T) {
-	server := NewMetricsServer("0.0.0.0", 9876, utils.Logger().Sugar())
+	server := NewMetricsServer("0.0.0.0", 9876, utils.Logger())
 
 	go func() {
 		time.Sleep(1 * time.Second)

--- a/waku/node.go
+++ b/waku/node.go
@@ -105,7 +105,7 @@ func Execute(options Options) {
 
 	var metricsServer *metrics.Server
 	if options.Metrics.Enable {
-		metricsServer = metrics.NewMetricsServer(options.Metrics.Address, options.Metrics.Port, logger.Sugar())
+		metricsServer = metrics.NewMetricsServer(options.Metrics.Address, options.Metrics.Port, logger)
 		go metricsServer.Start()
 	}
 

--- a/waku/node.go
+++ b/waku/node.go
@@ -190,7 +190,7 @@ func Execute(options Options) {
 	if options.Store.Enable {
 		nodeOpts = append(nodeOpts, node.WithWakuStoreAndRetentionPolicy(options.Store.ShouldResume, options.Store.RetentionMaxDaysDuration(), options.Store.RetentionMaxMessages))
 		if options.UseDB {
-			dbStore, err := persistence.NewDBStore(logger.Sugar(), persistence.WithDB(db), persistence.WithRetentionPolicy(options.Store.RetentionMaxMessages, options.Store.RetentionMaxDaysDuration()))
+			dbStore, err := persistence.NewDBStore(logger, persistence.WithDB(db), persistence.WithRetentionPolicy(options.Store.RetentionMaxMessages, options.Store.RetentionMaxDaysDuration()))
 			failOnErr(err, "DBStore")
 			nodeOpts = append(nodeOpts, node.WithMessageProvider(dbStore))
 		} else {

--- a/waku/node.go
+++ b/waku/node.go
@@ -299,7 +299,7 @@ func Execute(options Options) {
 
 	var rpcServer *rpc.WakuRpc
 	if options.RPCServer.Enable {
-		rpcServer = rpc.NewWakuRpc(wakuNode, options.RPCServer.Address, options.RPCServer.Port, options.RPCServer.Admin, options.RPCServer.Private, logger.Sugar())
+		rpcServer = rpc.NewWakuRpc(wakuNode, options.RPCServer.Address, options.RPCServer.Port, options.RPCServer.Admin, options.RPCServer.Private, logger)
 		rpcServer.Start()
 	}
 

--- a/waku/persistence/store.go
+++ b/waku/persistence/store.go
@@ -2,7 +2,6 @@ package persistence
 
 import (
 	"database/sql"
-	"fmt"
 	"time"
 
 	"github.com/status-im/go-waku/waku/v2/protocol/pb"
@@ -20,7 +19,7 @@ type MessageProvider interface {
 type DBStore struct {
 	MessageProvider
 	db  *sql.DB
-	log *zap.SugaredLogger
+	log *zap.Logger
 
 	maxMessages int
 	maxDuration time.Duration
@@ -67,7 +66,7 @@ func WithRetentionPolicy(maxMessages int, maxDuration time.Duration) DBOption {
 // Creates a new DB store using the db specified via options.
 // It will create a messages table if it does not exist and
 // clean up records according to the retention policy used
-func NewDBStore(log *zap.SugaredLogger, options ...DBOption) (*DBStore, error) {
+func NewDBStore(log *zap.Logger, options ...DBOption) (*DBStore, error) {
 	result := new(DBStore)
 	result.log = log.Named("dbstore")
 
@@ -124,7 +123,7 @@ func (d *DBStore) cleanOlderRecords() error {
 			return err
 		}
 		elapsed := time.Since(start)
-		d.log.Debug(fmt.Sprintf("Deleting older records from the DB took %s", elapsed))
+		d.log.Debug("deleting older records from the DB", zap.Duration("duration", elapsed))
 	}
 
 	// Limit number of records to a max N
@@ -136,7 +135,7 @@ func (d *DBStore) cleanOlderRecords() error {
 			return err
 		}
 		elapsed := time.Since(start)
-		d.log.Debug(fmt.Sprintf("Deleting excess records from the DB took %s", elapsed))
+		d.log.Debug("deleting excess records from the DB", zap.Duration("duration", elapsed))
 	}
 
 	return nil
@@ -166,7 +165,7 @@ func (d *DBStore) GetAll() ([]StoredMessage, error) {
 	start := time.Now()
 	defer func() {
 		elapsed := time.Since(start)
-		d.log.Info(fmt.Sprintf("Loading records from the DB took %s", elapsed))
+		d.log.Info("loading records from the DB", zap.Duration("duration", elapsed))
 	}()
 
 	rows, err := d.db.Query("SELECT id, receiverTimestamp, senderTimestamp, contentTopic, pubsubTopic, payload, version FROM message ORDER BY senderTimestamp ASC")
@@ -189,7 +188,7 @@ func (d *DBStore) GetAll() ([]StoredMessage, error) {
 
 		err = rows.Scan(&id, &receiverTimestamp, &senderTimestamp, &contentTopic, &pubsubTopic, &payload, &version)
 		if err != nil {
-			d.log.Fatal(err)
+			d.log.Fatal("scanning next row", zap.Error(err))
 		}
 
 		msg := new(pb.WakuMessage)
@@ -208,7 +207,7 @@ func (d *DBStore) GetAll() ([]StoredMessage, error) {
 		result = append(result, record)
 	}
 
-	d.log.Info(fmt.Sprintf("DB returned %d records", len(result)))
+	d.log.Info("DB returned records", zap.Int("count", len(result)))
 
 	err = rows.Err()
 	if err != nil {

--- a/waku/persistence/store_test.go
+++ b/waku/persistence/store_test.go
@@ -33,7 +33,7 @@ func createIndex(digest []byte, receiverTime int64) *pb.Index {
 func TestDbStore(t *testing.T) {
 	db := NewMock()
 	option := WithDB(db)
-	store, err := NewDBStore(utils.Logger().Sugar(), option)
+	store, err := NewDBStore(utils.Logger(), option)
 	require.NoError(t, err)
 
 	res, err := store.GetAll()
@@ -54,7 +54,7 @@ func TestDbStore(t *testing.T) {
 
 func TestStoreRetention(t *testing.T) {
 	db := NewMock()
-	store, err := NewDBStore(utils.Logger().Sugar(), WithDB(db), WithRetentionPolicy(5, 20*time.Second))
+	store, err := NewDBStore(utils.Logger(), WithDB(db), WithRetentionPolicy(5, 20*time.Second))
 	require.NoError(t, err)
 
 	insertTime := time.Now()
@@ -74,7 +74,7 @@ func TestStoreRetention(t *testing.T) {
 
 	// This step simulates starting go-waku again from scratch
 
-	store, err = NewDBStore(utils.Logger().Sugar(), WithDB(db), WithRetentionPolicy(5, 40*time.Second))
+	store, err = NewDBStore(utils.Logger(), WithDB(db), WithRetentionPolicy(5, 40*time.Second))
 	require.NoError(t, err)
 
 	dbResults, err = store.GetAll()

--- a/waku/v2/discv5/discover.go
+++ b/waku/v2/discv5/discover.go
@@ -215,7 +215,7 @@ func (d *DiscoveryV5) listen() error {
 	d.log.Info("started Discovery V5",
 		zap.Stringer("listening", d.udpAddr),
 		logging.TCPAddr("advertising", d.localnode.Node().IP(), d.localnode.Node().TCP()))
-	d.log.Info("Discovery V5: discoverable ENR ", logging.ENode("node", d.localnode.Node()))
+	d.log.Info("Discovery V5: discoverable ENR ", logging.ENode("enr", d.localnode.Node()))
 
 	return nil
 }
@@ -273,7 +273,7 @@ func (d *DiscoveryV5) UpdateAddr(addr *net.TCPAddr) error {
 	d.localnode.SetStaticIP(addr.IP)
 	d.localnode.Set(enr.TCP(uint16(addr.Port))) // lgtm [go/incorrect-integer-conversion]
 	d.log.Info("updated Discovery V5 node address", logging.TCPAddr("address", d.localnode.Node().IP(), d.localnode.Node().TCP()))
-	d.log.Info("Discovery V5", logging.ENode("node", d.localnode.Node()))
+	d.log.Info("Discovery V5", logging.ENode("enr", d.localnode.Node()))
 
 	return nil
 }
@@ -300,7 +300,7 @@ func hasTCPPort(node *enode.Node) bool {
 	enrTCP := new(enr.TCP)
 	if err := node.Record().Load(enr.WithEntry(enrTCP.ENRKey(), enrTCP)); err != nil {
 		if !enr.IsNotFound(err) {
-			utils.Logger().Named("discv5").Error("retrieving port for enr", logging.ENode("node", node))
+			utils.Logger().Named("discv5").Error("retrieving port for enr", logging.ENode("enr", node))
 		}
 		return false
 	}
@@ -321,7 +321,7 @@ func evaluateNode(node *enode.Node) bool {
 	_, err := utils.EnodeToPeerInfo(node)
 
 	if err != nil {
-		utils.Logger().Named("discv5").Error("obtaining peer info from enode", logging.ENode("node", node), zap.Error(err))
+		utils.Logger().Named("discv5").Error("obtaining peer info from enode", logging.ENode("enr", node), zap.Error(err))
 		return false
 	}
 

--- a/waku/v2/discv5/discover_test.go
+++ b/waku/v2/discv5/discover_test.go
@@ -47,19 +47,19 @@ func TestDiscV5(t *testing.T) {
 	host1, _, prvKey1 := createHost(t)
 	udpPort1, err := tests.FindFreePort(t, "127.0.0.1", 3)
 	require.NoError(t, err)
-	d1, err := NewDiscoveryV5(host1, host1.Addrs(), prvKey1, utils.NewWakuEnrBitfield(true, true, true, true), utils.Logger().Sugar(), WithUDPPort(udpPort1))
+	d1, err := NewDiscoveryV5(host1, host1.Addrs(), prvKey1, utils.NewWakuEnrBitfield(true, true, true, true), utils.Logger(), WithUDPPort(udpPort1))
 	require.NoError(t, err)
 
 	host2, _, prvKey2 := createHost(t)
 	udpPort2, err := tests.FindFreePort(t, "127.0.0.1", 3)
 	require.NoError(t, err)
-	d2, err := NewDiscoveryV5(host2, host2.Addrs(), prvKey2, utils.NewWakuEnrBitfield(true, true, true, true), utils.Logger().Sugar(), WithUDPPort(udpPort2), WithBootnodes([]*enode.Node{d1.localnode.Node()}))
+	d2, err := NewDiscoveryV5(host2, host2.Addrs(), prvKey2, utils.NewWakuEnrBitfield(true, true, true, true), utils.Logger(), WithUDPPort(udpPort2), WithBootnodes([]*enode.Node{d1.localnode.Node()}))
 	require.NoError(t, err)
 
 	host3, _, prvKey3 := createHost(t)
 	udpPort3, err := tests.FindFreePort(t, "127.0.0.1", 3)
 	require.NoError(t, err)
-	d3, err := NewDiscoveryV5(host3, host3.Addrs(), prvKey3, utils.NewWakuEnrBitfield(true, true, true, true), utils.Logger().Sugar(), WithUDPPort(udpPort3), WithBootnodes([]*enode.Node{d2.localnode.Node()}))
+	d3, err := NewDiscoveryV5(host3, host3.Addrs(), prvKey3, utils.NewWakuEnrBitfield(true, true, true, true), utils.Logger(), WithUDPPort(udpPort3), WithBootnodes([]*enode.Node{d2.localnode.Node()}))
 	require.NoError(t, err)
 
 	defer d1.Stop()

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -322,7 +322,7 @@ func (w *WakuNode) Start() error {
 		return err
 	}
 
-	w.lightPush = lightpush.NewWakuLightPush(w.ctx, w.host, w.relay, w.log.Sugar())
+	w.lightPush = lightpush.NewWakuLightPush(w.ctx, w.host, w.relay, w.log)
 	if w.opts.enableLightPush {
 		if err := w.lightPush.Start(); err != nil {
 			return err

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -283,7 +283,7 @@ func (w *WakuNode) checkForAddressChanges() {
 func (w *WakuNode) Start() error {
 	w.log.Info("Version details ", zap.String("commit", GitCommit))
 
-	w.swap = swap.NewWakuSwap(w.log.Sugar(), []swap.SwapOption{
+	w.swap = swap.NewWakuSwap(w.log, []swap.SwapOption{
 		swap.WithMode(w.opts.swapMode),
 		swap.WithThreshold(w.opts.swapPaymentThreshold, w.opts.swapDisconnectThreshold),
 	}...)

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -218,7 +218,7 @@ func (w *WakuNode) onAddrChange() {
 			if w.opts.enableDiscV5 {
 				err := w.discoveryV5.UpdateAddr(addr)
 				if err != nil {
-					w.log.Error("updating DiscV5 address with IP", zap.Stringer("ip", addr.IP), zap.Int("port", addr.Port), zap.Error(err))
+					w.log.Error("updating DiscV5 address with IP", zap.Stringer("address", addr), zap.Error(err))
 					continue
 				}
 			}
@@ -235,7 +235,7 @@ func (w *WakuNode) logAddress(addr ma.Multiaddr) {
 		if err != nil {
 			logger.Error("obtaining ENR record from multiaddress", zap.Error(err))
 		} else {
-			logger.Info("listening", zap.Stringer("ENR", enr), zap.Stringer("ip", ip))
+			logger.Info("listening", logging.ENode("enr", enr), zap.Stringer("ip", ip))
 		}
 	}
 }
@@ -492,7 +492,7 @@ func (w *WakuNode) mountDiscV5() error {
 	}
 
 	var err error
-	w.discoveryV5, err = discv5.NewDiscoveryV5(w.Host(), w.ListenAddresses(), w.opts.privKey, w.wakuFlag, w.log.Sugar(), discV5Options...)
+	w.discoveryV5, err = discv5.NewDiscoveryV5(w.Host(), w.ListenAddresses(), w.opts.privKey, w.wakuFlag, w.log, discV5Options...)
 
 	return err
 }

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -86,7 +86,7 @@ type WakuNode struct {
 }
 
 func defaultStoreFactory(w *WakuNode) store.Store {
-	return store.NewWakuStore(w.host, w.swap, w.opts.messageProvider, w.opts.maxMessages, w.opts.maxDuration, w.log.Sugar())
+	return store.NewWakuStore(w.host, w.swap, w.opts.messageProvider, w.opts.maxMessages, w.opts.maxDuration, w.log)
 }
 
 // New is used to instantiate a WakuNode using a set of WakuNodeOptions

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -294,7 +294,7 @@ func (w *WakuNode) Start() error {
 	}
 
 	if w.opts.enableFilter {
-		filter, err := filter.NewWakuFilter(w.ctx, w.host, w.opts.isFilterFullNode, w.log.Sugar(), w.opts.filterOpts...)
+		filter, err := filter.NewWakuFilter(w.ctx, w.host, w.opts.isFilterFullNode, w.log, w.opts.filterOpts...)
 		if err != nil {
 			return err
 		}

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -462,7 +462,7 @@ func (w *WakuNode) Publish(ctx context.Context, msg *pb.WakuMessage) error {
 
 func (w *WakuNode) mountRelay(minRelayPeersToPublish int, opts ...pubsub.Option) error {
 	var err error
-	w.relay, err = relay.NewWakuRelay(w.ctx, w.host, w.bcaster, minRelayPeersToPublish, w.log.Sugar(), opts...)
+	w.relay, err = relay.NewWakuRelay(w.ctx, w.host, w.bcaster, minRelayPeersToPublish, w.log, opts...)
 	if err != nil {
 		return err
 	}

--- a/waku/v2/node/wakuoptions_test.go
+++ b/waku/v2/node/wakuoptions_test.go
@@ -30,7 +30,7 @@ func TestWakuOptions(t *testing.T) {
 	advertiseAddr, _ := net.ResolveTCPAddr("tcp", "0.0.0.0:0")
 
 	storeFactory := func(w *WakuNode) store.Store {
-		return store.NewWakuStore(w.host, w.swap, w.opts.messageProvider, w.opts.maxMessages, w.opts.maxDuration, w.log.Sugar())
+		return store.NewWakuStore(w.host, w.swap, w.opts.messageProvider, w.opts.maxMessages, w.opts.maxDuration, w.log)
 	}
 
 	options := []WakuNodeOption{

--- a/waku/v2/protocol/filter/waku_filter_option.go
+++ b/waku/v2/protocol/filter/waku_filter_option.go
@@ -14,7 +14,7 @@ type (
 	FilterSubscribeParameters struct {
 		host         host.Host
 		selectedPeer peer.ID
-		log          *zap.SugaredLogger
+		log          *zap.Logger
 	}
 
 	FilterSubscribeOption func(*FilterSubscribeParameters)
@@ -40,22 +40,22 @@ func WithPeer(p peer.ID) FilterSubscribeOption {
 
 func WithAutomaticPeerSelection() FilterSubscribeOption {
 	return func(params *FilterSubscribeParameters) {
-		p, err := utils.SelectPeer(params.host, string(FilterID_v20beta1), params.log.Desugar())
+		p, err := utils.SelectPeer(params.host, string(FilterID_v20beta1), params.log)
 		if err == nil {
 			params.selectedPeer = *p
 		} else {
-			params.log.Info("Error selecting peer: ", err)
+			params.log.Info("selecting peer", zap.Error(err))
 		}
 	}
 }
 
 func WithFastestPeerSelection(ctx context.Context) FilterSubscribeOption {
 	return func(params *FilterSubscribeParameters) {
-		p, err := utils.SelectPeerWithLowestRTT(ctx, params.host, string(FilterID_v20beta1), params.log.Desugar())
+		p, err := utils.SelectPeerWithLowestRTT(ctx, params.host, string(FilterID_v20beta1), params.log)
 		if err == nil {
 			params.selectedPeer = *p
 		} else {
-			params.log.Info("Error selecting peer: ", err)
+			params.log.Info("selecting peer", zap.Error(err))
 		}
 	}
 }

--- a/waku/v2/protocol/filter/waku_filter_option_test.go
+++ b/waku/v2/protocol/filter/waku_filter_option_test.go
@@ -25,7 +25,7 @@ func TestFilterOption(t *testing.T) {
 
 	params := new(FilterSubscribeParameters)
 	params.host = host
-	params.log = utils.Logger().Sugar()
+	params.log = utils.Logger()
 
 	for _, opt := range options {
 		opt(params)

--- a/waku/v2/protocol/filter/waku_filter_test.go
+++ b/waku/v2/protocol/filter/waku_filter_test.go
@@ -23,7 +23,7 @@ func makeWakuRelay(t *testing.T, topic string, broadcaster v2.Broadcaster) (*rel
 	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
 
-	relay, err := relay.NewWakuRelay(context.Background(), host, broadcaster, 0, utils.Logger().Sugar())
+	relay, err := relay.NewWakuRelay(context.Background(), host, broadcaster, 0, utils.Logger())
 	require.NoError(t, err)
 
 	sub, err := relay.SubscribeToTopic(context.Background(), topic)

--- a/waku/v2/protocol/filter/waku_filter_test.go
+++ b/waku/v2/protocol/filter/waku_filter_test.go
@@ -39,7 +39,7 @@ func makeWakuFilter(t *testing.T) (*WakuFilter, host.Host) {
 	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
 
-	filter, _ := NewWakuFilter(context.Background(), host, false, utils.Logger().Sugar())
+	filter, _ := NewWakuFilter(context.Background(), host, false, utils.Logger())
 
 	return filter, host
 }
@@ -69,7 +69,7 @@ func TestWakuFilter(t *testing.T) {
 	defer node2.Stop()
 	defer sub2.Unsubscribe()
 
-	node2Filter, _ := NewWakuFilter(ctx, host2, true, utils.Logger().Sugar())
+	node2Filter, _ := NewWakuFilter(ctx, host2, true, utils.Logger())
 	broadcaster.Register(&testTopic, node2Filter.MsgC)
 
 	host1.Peerstore().AddAddr(host2.ID(), tests.GetHostAddress(host2), peerstore.PermanentAddrTTL)
@@ -154,7 +154,7 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 	defer node2.Stop()
 	defer sub2.Unsubscribe()
 
-	node2Filter, _ := NewWakuFilter(ctx, host2, true, utils.Logger().Sugar(), WithTimeout(3*time.Second))
+	node2Filter, _ := NewWakuFilter(ctx, host2, true, utils.Logger(), WithTimeout(3*time.Second))
 	broadcaster.Register(&testTopic, node2Filter.MsgC)
 
 	host1.Peerstore().AddAddr(host2.ID(), tests.GetHostAddress(host2), peerstore.PermanentAddrTTL)

--- a/waku/v2/protocol/lightpush/waku_lightpush_option.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_option.go
@@ -14,7 +14,7 @@ type LightPushParameters struct {
 	host         host.Host
 	selectedPeer peer.ID
 	requestId    []byte
-	log          *zap.SugaredLogger
+	log          *zap.Logger
 }
 
 type LightPushOption func(*LightPushParameters)
@@ -27,22 +27,22 @@ func WithPeer(p peer.ID) LightPushOption {
 
 func WithAutomaticPeerSelection(host host.Host) LightPushOption {
 	return func(params *LightPushParameters) {
-		p, err := utils.SelectPeer(host, string(LightPushID_v20beta1), params.log.Desugar())
+		p, err := utils.SelectPeer(host, string(LightPushID_v20beta1), params.log)
 		if err == nil {
 			params.selectedPeer = *p
 		} else {
-			params.log.Info("Error selecting peer: ", err)
+			params.log.Info("selecting peer", zap.Error(err))
 		}
 	}
 }
 
 func WithFastestPeerSelection(ctx context.Context) LightPushOption {
 	return func(params *LightPushParameters) {
-		p, err := utils.SelectPeerWithLowestRTT(ctx, params.host, string(LightPushID_v20beta1), params.log.Desugar())
+		p, err := utils.SelectPeerWithLowestRTT(ctx, params.host, string(LightPushID_v20beta1), params.log)
 		if err == nil {
 			params.selectedPeer = *p
 		} else {
-			params.log.Info("Error selecting peer: ", err)
+			params.log.Info("selecting peer", zap.Error(err))
 		}
 	}
 }

--- a/waku/v2/protocol/lightpush/waku_lightpush_option_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_option_test.go
@@ -27,7 +27,7 @@ func TestLightPushOption(t *testing.T) {
 
 	params := new(LightPushParameters)
 	params.host = host
-	params.log = utils.Logger().Sugar()
+	params.log = utils.Logger()
 
 	for _, opt := range options {
 		opt(params)

--- a/waku/v2/protocol/lightpush/waku_lightpush_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_test.go
@@ -25,7 +25,7 @@ func makeWakuRelay(t *testing.T, topic string) (*relay.WakuRelay, *relay.Subscri
 	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
 
-	relay, err := relay.NewWakuRelay(context.Background(), host, v2.NewBroadcaster(10), 0, utils.Logger().Sugar())
+	relay, err := relay.NewWakuRelay(context.Background(), host, v2.NewBroadcaster(10), 0, utils.Logger())
 	require.NoError(t, err)
 
 	sub, err := relay.SubscribeToTopic(context.Background(), topic)

--- a/waku/v2/protocol/lightpush/waku_lightpush_test.go
+++ b/waku/v2/protocol/lightpush/waku_lightpush_test.go
@@ -56,7 +56,7 @@ func TestWakuLightPush(t *testing.T) {
 	defer sub2.Unsubscribe()
 
 	ctx := context.Background()
-	lightPushNode2 := NewWakuLightPush(ctx, host2, node2, utils.Logger().Sugar())
+	lightPushNode2 := NewWakuLightPush(ctx, host2, node2, utils.Logger())
 	err := lightPushNode2.Start()
 	require.NoError(t, err)
 	defer lightPushNode2.Stop()
@@ -66,7 +66,7 @@ func TestWakuLightPush(t *testing.T) {
 
 	clientHost, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
-	client := NewWakuLightPush(ctx, clientHost, nil, utils.Logger().Sugar())
+	client := NewWakuLightPush(ctx, clientHost, nil, utils.Logger())
 
 	host2.Peerstore().AddAddr(host1.ID(), tests.GetHostAddress(host1), peerstore.PermanentAddrTTL)
 	err = host2.Peerstore().AddProtocols(host1.ID(), string(relay.WakuRelayID_v200))
@@ -122,7 +122,7 @@ func TestWakuLightPushStartWithoutRelay(t *testing.T) {
 
 	clientHost, err := tests.MakeHost(context.Background(), 0, rand.Reader)
 	require.NoError(t, err)
-	client := NewWakuLightPush(ctx, clientHost, nil, utils.Logger().Sugar())
+	client := NewWakuLightPush(ctx, clientHost, nil, utils.Logger())
 	err = client.Start()
 
 	require.Errorf(t, err, "relay is required")
@@ -136,7 +136,7 @@ func TestWakuLightPushNoPeers(t *testing.T) {
 
 	clientHost, err := tests.MakeHost(context.Background(), 0, rand.Reader)
 	require.NoError(t, err)
-	client := NewWakuLightPush(ctx, clientHost, nil, utils.Logger().Sugar())
+	client := NewWakuLightPush(ctx, clientHost, nil, utils.Logger())
 
 	_, err = client.PublishToTopic(ctx, tests.CreateWakuMessage("test", 0), testTopic)
 	require.Errorf(t, err, "no suitable remote peers")

--- a/waku/v2/protocol/relay/waku_relay_test.go
+++ b/waku/v2/protocol/relay/waku_relay_test.go
@@ -20,7 +20,7 @@ func TestWakuRelay(t *testing.T) {
 	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
 
-	relay, err := NewWakuRelay(context.Background(), host, nil, 0, utils.Logger().Sugar())
+	relay, err := NewWakuRelay(context.Background(), host, nil, 0, utils.Logger())
 	defer relay.Stop()
 	require.NoError(t, err)
 

--- a/waku/v2/protocol/store/waku_resume_test.go
+++ b/waku/v2/protocol/store/waku_resume_test.go
@@ -21,7 +21,7 @@ func TestFindLastSeenMessage(t *testing.T) {
 	msg4 := protocol.NewEnvelope(tests.CreateWakuMessage("4", 4), "test")
 	msg5 := protocol.NewEnvelope(tests.CreateWakuMessage("5", 5), "test")
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	_ = s.storeMessage(msg1)
 	_ = s.storeMessage(msg3)
 	_ = s.storeMessage(msg5)
@@ -38,7 +38,7 @@ func TestResume(t *testing.T) {
 	host1, err := libp2p.New(libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger().Sugar())
+	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger())
 	s1.Start(ctx)
 	defer s1.Stop()
 
@@ -56,7 +56,7 @@ func TestResume(t *testing.T) {
 	host2, err := libp2p.New(libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger().Sugar())
+	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger())
 	s2.Start(ctx)
 	defer s2.Stop()
 
@@ -88,7 +88,7 @@ func TestResumeWithListOfPeers(t *testing.T) {
 	host1, err := libp2p.New(libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger().Sugar())
+	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger())
 	s1.Start(ctx)
 	defer s1.Stop()
 
@@ -99,7 +99,7 @@ func TestResumeWithListOfPeers(t *testing.T) {
 	host2, err := libp2p.New(libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger().Sugar())
+	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger())
 	s2.Start(ctx)
 	defer s2.Stop()
 
@@ -121,7 +121,7 @@ func TestResumeWithoutSpecifyingPeer(t *testing.T) {
 	host1, err := libp2p.New(libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger().Sugar())
+	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger())
 	s1.Start(ctx)
 	defer s1.Stop()
 
@@ -132,7 +132,7 @@ func TestResumeWithoutSpecifyingPeer(t *testing.T) {
 	host2, err := libp2p.New(libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger().Sugar())
+	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger())
 	s2.Start(ctx)
 	defer s2.Stop()
 

--- a/waku/v2/protocol/store/waku_store_persistence_test.go
+++ b/waku/v2/protocol/store/waku_store_persistence_test.go
@@ -21,7 +21,7 @@ func TestStorePersistence(t *testing.T) {
 	db, err := sqlite.NewDB(":memory:")
 	require.NoError(t, err)
 
-	dbStore, err := persistence.NewDBStore(utils.Logger().Sugar(), persistence.WithDB(db))
+	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db))
 	require.NoError(t, err)
 
 	s1 := NewWakuStore(nil, nil, dbStore, 0, 0, utils.Logger().Sugar())

--- a/waku/v2/protocol/store/waku_store_persistence_test.go
+++ b/waku/v2/protocol/store/waku_store_persistence_test.go
@@ -24,7 +24,7 @@ func TestStorePersistence(t *testing.T) {
 	dbStore, err := persistence.NewDBStore(utils.Logger(), persistence.WithDB(db))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(nil, nil, dbStore, 0, 0, utils.Logger().Sugar())
+	s1 := NewWakuStore(nil, nil, dbStore, 0, 0, utils.Logger())
 	s1.fetchDBRecords(ctx)
 	require.Len(t, s1.messageQueue.messages, 0)
 
@@ -39,7 +39,7 @@ func TestStorePersistence(t *testing.T) {
 
 	_ = s1.storeMessage(protocol.NewEnvelope(msg, defaultPubSubTopic))
 
-	s2 := NewWakuStore(nil, nil, dbStore, 0, 0, utils.Logger().Sugar())
+	s2 := NewWakuStore(nil, nil, dbStore, 0, 0, utils.Logger())
 	s2.fetchDBRecords(ctx)
 	require.Len(t, s2.messageQueue.messages, 1)
 	require.Equal(t, msg, s2.messageQueue.messages[0].msg)

--- a/waku/v2/protocol/store/waku_store_protocol_test.go
+++ b/waku/v2/protocol/store/waku_store_protocol_test.go
@@ -20,7 +20,7 @@ func TestWakuStoreProtocolQuery(t *testing.T) {
 	host1, err := libp2p.New(libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger().Sugar())
+	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger())
 	s1.Start(ctx)
 	defer s1.Stop()
 
@@ -39,7 +39,7 @@ func TestWakuStoreProtocolQuery(t *testing.T) {
 	// Simulate a message has been received via relay protocol
 	s1.MsgC <- protocol.NewEnvelope(msg, pubsubTopic1)
 
-	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger().Sugar())
+	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger())
 	s2.Start(ctx)
 	defer s2.Stop()
 
@@ -66,7 +66,7 @@ func TestWakuStoreProtocolNext(t *testing.T) {
 	host1, err := libp2p.New(libp2p.DefaultTransports, libp2p.ListenAddrStrings("/ip4/0.0.0.0/tcp/0"))
 	require.NoError(t, err)
 
-	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger().Sugar())
+	s1 := NewWakuStore(host1, nil, nil, 0, 0, utils.Logger())
 	s1.Start(ctx)
 	defer s1.Stop()
 
@@ -92,7 +92,7 @@ func TestWakuStoreProtocolNext(t *testing.T) {
 	err = host2.Peerstore().AddProtocols(host1.ID(), string(StoreID_v20beta4))
 	require.NoError(t, err)
 
-	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger().Sugar())
+	s2 := NewWakuStore(host2, nil, nil, 0, 0, utils.Logger())
 	s2.Start(ctx)
 	defer s2.Stop()
 

--- a/waku/v2/protocol/store/waku_store_query_test.go
+++ b/waku/v2/protocol/store/waku_store_query_test.go
@@ -17,7 +17,7 @@ func TestStoreQuery(t *testing.T) {
 	msg1 := tests.CreateWakuMessage(defaultContentTopic, utils.GetUnixEpoch())
 	msg2 := tests.CreateWakuMessage("2", utils.GetUnixEpoch())
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	_ = s.storeMessage(protocol.NewEnvelope(msg1, defaultPubSubTopic))
 	_ = s.storeMessage(protocol.NewEnvelope(msg2, defaultPubSubTopic))
 
@@ -43,7 +43,7 @@ func TestStoreQueryMultipleContentFilters(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, utils.GetUnixEpoch())
 	msg3 := tests.CreateWakuMessage(topic3, utils.GetUnixEpoch())
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 
 	_ = s.storeMessage(protocol.NewEnvelope(msg1, defaultPubSubTopic))
 	_ = s.storeMessage(protocol.NewEnvelope(msg2, defaultPubSubTopic))
@@ -77,7 +77,7 @@ func TestStoreQueryPubsubTopicFilter(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, utils.GetUnixEpoch())
 	msg3 := tests.CreateWakuMessage(topic3, utils.GetUnixEpoch())
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	_ = s.storeMessage(protocol.NewEnvelope(msg1, pubsubTopic1))
 	_ = s.storeMessage(protocol.NewEnvelope(msg2, pubsubTopic2))
 	_ = s.storeMessage(protocol.NewEnvelope(msg3, pubsubTopic2))
@@ -109,7 +109,7 @@ func TestStoreQueryPubsubTopicNoMatch(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, utils.GetUnixEpoch())
 	msg3 := tests.CreateWakuMessage(topic3, utils.GetUnixEpoch())
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	_ = s.storeMessage(protocol.NewEnvelope(msg1, pubsubTopic2))
 	_ = s.storeMessage(protocol.NewEnvelope(msg2, pubsubTopic2))
 	_ = s.storeMessage(protocol.NewEnvelope(msg3, pubsubTopic2))
@@ -131,7 +131,7 @@ func TestStoreQueryPubsubTopicAllMessages(t *testing.T) {
 	msg2 := tests.CreateWakuMessage(topic2, utils.GetUnixEpoch())
 	msg3 := tests.CreateWakuMessage(topic3, utils.GetUnixEpoch())
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	_ = s.storeMessage(protocol.NewEnvelope(msg1, pubsubTopic1))
 	_ = s.storeMessage(protocol.NewEnvelope(msg2, pubsubTopic1))
 	_ = s.storeMessage(protocol.NewEnvelope(msg3, pubsubTopic1))
@@ -150,7 +150,7 @@ func TestStoreQueryForwardPagination(t *testing.T) {
 	topic1 := "1"
 	pubsubTopic1 := "topic1"
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	for i := 0; i < 10; i++ {
 		msg := tests.CreateWakuMessage(topic1, utils.GetUnixEpoch())
 		msg.Payload = []byte{byte(i)}
@@ -174,7 +174,7 @@ func TestStoreQueryBackwardPagination(t *testing.T) {
 	topic1 := "1"
 	pubsubTopic1 := "topic1"
 
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 	for i := 0; i < 10; i++ {
 		msg := &pb.WakuMessage{
 			Payload:      []byte{byte(i)},
@@ -200,7 +200,7 @@ func TestStoreQueryBackwardPagination(t *testing.T) {
 }
 
 func TestTemporalHistoryQueries(t *testing.T) {
-	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger().Sugar())
+	s := NewWakuStore(nil, nil, nil, 0, 0, utils.Logger())
 
 	var messages []*pb.WakuMessage
 	for i := 0; i < 10; i++ {

--- a/waku/v2/protocol/swap/waku_swap.go
+++ b/waku/v2/protocol/swap/waku_swap.go
@@ -18,13 +18,13 @@ const WakuSwapID_v200 = protocol.ID("/vac/waku/swap/2.0.0-beta1")
 type WakuSwap struct {
 	params *SwapParameters
 
-	log *zap.SugaredLogger
+	log *zap.Logger
 
 	Accounting      map[string]int
 	accountingMutex sync.RWMutex
 }
 
-func NewWakuSwap(log *zap.SugaredLogger, opts ...SwapOption) *WakuSwap {
+func NewWakuSwap(log *zap.Logger, opts ...SwapOption) *WakuSwap {
 	params := &SwapParameters{}
 
 	optList := DefaultOptions()
@@ -45,12 +45,13 @@ func (s *WakuSwap) sendCheque(peerId string) {
 }
 
 func (s *WakuSwap) applyPolicy(peerId string) {
+	logger := s.log.With(zap.String("peer", peerId))
 	if s.Accounting[peerId] <= s.params.disconnectThreshold {
-		s.log.Warnf("Disconnect threshold has been reached for %s at %d", peerId, s.Accounting[peerId])
+		logger.Warn("disconnect threshold reached", zap.Int("value", s.Accounting[peerId]))
 	}
 
 	if s.Accounting[peerId] >= s.params.paymentThreshold {
-		s.log.Warnf("Disconnect threshold has been reached for %s at %d", peerId, s.Accounting[peerId])
+		logger.Warn("payment threshold reached", zap.Int("value", s.Accounting[peerId]))
 		if s.params.mode != HardMode {
 			s.sendCheque(peerId)
 		}

--- a/waku/v2/protocol/swap/waku_swap_test.go
+++ b/waku/v2/protocol/swap/waku_swap_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSwapCreditDebit(t *testing.T) {
-	swap := NewWakuSwap(utils.Logger().Sugar(), []SwapOption{
+	swap := NewWakuSwap(utils.Logger(), []SwapOption{
 		WithMode(SoftMode),
 		WithThreshold(0, 0),
 	}...)

--- a/waku/v2/rpc/admin.go
+++ b/waku/v2/rpc/admin.go
@@ -15,7 +15,7 @@ import (
 
 type AdminService struct {
 	node *node.WakuNode
-	log  *zap.SugaredLogger
+	log  *zap.Logger
 }
 
 type GetPeersArgs struct {
@@ -39,7 +39,7 @@ func (a *AdminService) PostV1Peers(req *http.Request, args *PeersArgs, reply *Su
 	for _, peer := range args.Peers {
 		addr, err := ma.NewMultiaddr(peer)
 		if err != nil {
-			a.log.Error("Error building multiaddr", zap.Error(err))
+			a.log.Error("building multiaddr", zap.Error(err))
 			reply.Success = false
 			reply.Error = err.Error()
 			return nil
@@ -47,7 +47,7 @@ func (a *AdminService) PostV1Peers(req *http.Request, args *PeersArgs, reply *Su
 
 		err = a.node.DialPeerWithMultiAddress(req.Context(), addr)
 		if err != nil {
-			a.log.Error("Error dialing peers", zap.Error(err))
+			a.log.Error("dialing peers", zap.Error(err))
 			reply.Success = false
 			reply.Error = err.Error()
 			return nil
@@ -65,7 +65,7 @@ func isWakuProtocol(protocol string) bool {
 func (a *AdminService) GetV1Peers(req *http.Request, args *GetPeersArgs, reply *PeersReply) error {
 	peers, err := a.node.Peers()
 	if err != nil {
-		a.log.Error("Error getting peers", zap.Error(err))
+		a.log.Error("getting peers", zap.Error(err))
 		return nil
 	}
 	for _, peer := range peers {

--- a/waku/v2/rpc/admin_test.go
+++ b/waku/v2/rpc/admin_test.go
@@ -24,7 +24,7 @@ func makeAdminService(t *testing.T) *AdminService {
 	require.NoError(t, err)
 	err = n.Start()
 	require.NoError(t, err)
-	return &AdminService{n, utils.Logger().Sugar()}
+	return &AdminService{n, utils.Logger()}
 }
 
 func TestV1Peers(t *testing.T) {

--- a/waku/v2/rpc/admin_test.go
+++ b/waku/v2/rpc/admin_test.go
@@ -33,7 +33,7 @@ func TestV1Peers(t *testing.T) {
 
 	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
-	relay, err := relay.NewWakuRelay(context.Background(), host, nil, 0, utils.Logger().Sugar())
+	relay, err := relay.NewWakuRelay(context.Background(), host, nil, 0, utils.Logger())
 	require.NoError(t, err)
 	defer relay.Stop()
 

--- a/waku/v2/rpc/filter.go
+++ b/waku/v2/rpc/filter.go
@@ -14,7 +14,7 @@ import (
 
 type FilterService struct {
 	node *node.WakuNode
-	log  *zap.SugaredLogger
+	log  *zap.Logger
 
 	messages      map[string][]*pb.WakuMessage
 	messagesMutex sync.RWMutex
@@ -31,7 +31,7 @@ type ContentTopicArgs struct {
 	ContentTopic string `json:"contentTopic,omitempty"`
 }
 
-func NewFilterService(node *node.WakuNode, log *zap.SugaredLogger) *FilterService {
+func NewFilterService(node *node.WakuNode, log *zap.Logger) *FilterService {
 	s := &FilterService{
 		node:     node,
 		log:      log.Named("filter"),
@@ -80,7 +80,7 @@ func (f *FilterService) PostV1Subscription(req *http.Request, args *FilterConten
 		filter.WithAutomaticPeerSelection(),
 	)
 	if err != nil {
-		f.log.Error("Error subscribing to topic:", args.Topic, "err:", err)
+		f.log.Error("subscribing to topic", zap.String("topic", args.Topic), zap.Error(err))
 		reply.Success = false
 		reply.Error = err.Error()
 		return nil
@@ -98,7 +98,7 @@ func (f *FilterService) DeleteV1Subscription(req *http.Request, args *FilterCont
 		makeContentFilter(args),
 	)
 	if err != nil {
-		f.log.Error("Error unsubscribing to topic:", args.Topic, "err:", err)
+		f.log.Error("unsubscribing from topic", zap.String("topic", args.Topic), zap.Error(err))
 		reply.Success = false
 		reply.Error = err.Error()
 		return nil

--- a/waku/v2/rpc/filter_test.go
+++ b/waku/v2/rpc/filter_test.go
@@ -29,7 +29,7 @@ func makeFilterService(t *testing.T) *FilterService {
 	_, err = n.Relay().SubscribeToTopic(context.Background(), testTopic)
 	require.NoError(t, err)
 
-	return NewFilterService(n, utils.Logger().Sugar())
+	return NewFilterService(n, utils.Logger())
 }
 
 func TestFilterSubscription(t *testing.T) {

--- a/waku/v2/rpc/filter_test.go
+++ b/waku/v2/rpc/filter_test.go
@@ -45,7 +45,7 @@ func TestFilterSubscription(t *testing.T) {
 	_, err = node.SubscribeToTopic(context.Background(), testTopic)
 	require.NoError(t, err)
 
-	_, _ = filter.NewWakuFilter(context.Background(), host, false, utils.Logger().Sugar())
+	_, _ = filter.NewWakuFilter(context.Background(), host, false, utils.Logger())
 
 	d := makeFilterService(t)
 	defer d.node.Stop()

--- a/waku/v2/rpc/filter_test.go
+++ b/waku/v2/rpc/filter_test.go
@@ -39,7 +39,7 @@ func TestFilterSubscription(t *testing.T) {
 	host, err := tests.MakeHost(context.Background(), port, rand.Reader)
 	require.NoError(t, err)
 
-	node, err := relay.NewWakuRelay(context.Background(), host, v2.NewBroadcaster(10), 0, utils.Logger().Sugar())
+	node, err := relay.NewWakuRelay(context.Background(), host, v2.NewBroadcaster(10), 0, utils.Logger())
 	require.NoError(t, err)
 
 	_, err = node.SubscribeToTopic(context.Background(), testTopic)

--- a/waku/v2/rpc/private.go
+++ b/waku/v2/rpc/private.go
@@ -16,7 +16,7 @@ import (
 
 type PrivateService struct {
 	node *node.WakuNode
-	log  *zap.SugaredLogger
+	log  *zap.Logger
 
 	symmetricMessages      map[string][]*pb.WakuMessage
 	symmetricMessagesMutex sync.RWMutex
@@ -56,7 +56,7 @@ type AsymmetricMessagesArgs struct {
 	PrivateKey string `json:"privateKey"`
 }
 
-func NewPrivateService(node *node.WakuNode, log *zap.SugaredLogger) *PrivateService {
+func NewPrivateService(node *node.WakuNode, log *zap.Logger) *PrivateService {
 	return &PrivateService{
 		node:               node,
 		symmetricMessages:  make(map[string][]*pb.WakuMessage),

--- a/waku/v2/rpc/private_test.go
+++ b/waku/v2/rpc/private_test.go
@@ -16,7 +16,7 @@ func makePrivateService(t *testing.T) *PrivateService {
 	err = n.Start()
 	require.NoError(t, err)
 
-	return NewPrivateService(n, utils.Logger().Sugar())
+	return NewPrivateService(n, utils.Logger())
 }
 
 func TestGetV1SymmetricKey(t *testing.T) {

--- a/waku/v2/rpc/relay_test.go
+++ b/waku/v2/rpc/relay_test.go
@@ -19,7 +19,7 @@ func makeRelayService(t *testing.T) *RelayService {
 	require.NoError(t, err)
 	err = n.Start()
 	require.NoError(t, err)
-	return NewRelayService(n, utils.Logger().Sugar())
+	return NewRelayService(n, utils.Logger())
 }
 
 func TestPostV1Message(t *testing.T) {

--- a/waku/v2/rpc/store.go
+++ b/waku/v2/rpc/store.go
@@ -11,7 +11,7 @@ import (
 
 type StoreService struct {
 	node *node.WakuNode
-	log  *zap.SugaredLogger
+	log  *zap.Logger
 }
 
 // cursor       *pb.Index
@@ -56,7 +56,7 @@ func (s *StoreService) GetV1Messages(req *http.Request, args *StoreMessagesArgs,
 		options...,
 	)
 	if err != nil {
-		s.log.Error("Error querying messages:", zap.Error(err))
+		s.log.Error("querying messages", zap.Error(err))
 		reply.Error = err.Error()
 		return nil
 	}

--- a/waku/v2/rpc/store_test.go
+++ b/waku/v2/rpc/store_test.go
@@ -15,7 +15,7 @@ func makeStoreService(t *testing.T) *StoreService {
 	require.NoError(t, err)
 	err = n.Start()
 	require.NoError(t, err)
-	return &StoreService{n, utils.Logger().Sugar()}
+	return &StoreService{n, utils.Logger()}
 }
 
 func TestStoreGetV1Messages(t *testing.T) {

--- a/waku/v2/rpc/waku_rpc.go
+++ b/waku/v2/rpc/waku_rpc.go
@@ -15,7 +15,7 @@ type WakuRpc struct {
 	node   *node.WakuNode
 	server *http.Server
 
-	log *zap.SugaredLogger
+	log *zap.Logger
 
 	relayService   *RelayService
 	filterService  *FilterService
@@ -23,7 +23,7 @@ type WakuRpc struct {
 	adminService   *AdminService
 }
 
-func NewWakuRpc(node *node.WakuNode, address string, port int, enableAdmin bool, enablePrivate bool, log *zap.SugaredLogger) *WakuRpc {
+func NewWakuRpc(node *node.WakuNode, address string, port int, enableAdmin bool, enablePrivate bool, log *zap.Logger) *WakuRpc {
 	wrpc := new(WakuRpc)
 	wrpc.log = log.Named("rpc")
 
@@ -33,25 +33,25 @@ func NewWakuRpc(node *node.WakuNode, address string, port int, enableAdmin bool,
 
 	err := s.RegisterService(&DebugService{node}, "Debug")
 	if err != nil {
-		wrpc.log.Error(err)
+		wrpc.log.Error("registering debug service", zap.Error(err))
 	}
 
 	relayService := NewRelayService(node, log)
 	err = s.RegisterService(relayService, "Relay")
 	if err != nil {
-		wrpc.log.Error(err)
+		wrpc.log.Error("registering relay service", zap.Error(err))
 	}
 
 	err = s.RegisterService(&StoreService{node, log}, "Store")
 	if err != nil {
-		wrpc.log.Error(err)
+		wrpc.log.Error("registering store service", zap.Error(err))
 	}
 
 	if enableAdmin {
 		adminService := &AdminService{node, log.Named("admin")}
 		err = s.RegisterService(adminService, "Admin")
 		if err != nil {
-			wrpc.log.Error(err)
+			wrpc.log.Error("registering admin service", zap.Error(err))
 		}
 		wrpc.adminService = adminService
 	}
@@ -59,14 +59,14 @@ func NewWakuRpc(node *node.WakuNode, address string, port int, enableAdmin bool,
 	filterService := NewFilterService(node, log)
 	err = s.RegisterService(filterService, "Filter")
 	if err != nil {
-		wrpc.log.Error(err)
+		wrpc.log.Error("registering filter service", zap.Error(err))
 	}
 
 	if enablePrivate {
 		privateService := NewPrivateService(node, log)
 		err = s.RegisterService(privateService, "Private")
 		if err != nil {
-			wrpc.log.Error(err)
+			wrpc.log.Error("registering private service", zap.Error(err))
 		}
 		wrpc.privateService = privateService
 	}
@@ -75,7 +75,7 @@ func NewWakuRpc(node *node.WakuNode, address string, port int, enableAdmin bool,
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		t := time.Now()
 		s.ServeHTTP(w, r)
-		wrpc.log.Infof("RPC request at %s took %s", r.URL.Path, time.Since(t))
+		wrpc.log.Info("served request", zap.String("path", r.URL.Path), zap.Duration("duration", time.Since(t)))
 	})
 
 	listenAddr := fmt.Sprintf("%s:%d", address, port)
@@ -104,10 +104,10 @@ func (r *WakuRpc) Start() {
 	go func() {
 		_ = r.server.ListenAndServe()
 	}()
-	r.log.Info("Rpc server started at ", r.server.Addr)
+	r.log.Info("server started", zap.String("addr", r.server.Addr))
 }
 
 func (r *WakuRpc) Stop(ctx context.Context) error {
-	r.log.Info("Shutting down rpc server")
+	r.log.Info("shutting down server")
 	return r.server.Shutdown(ctx)
 }

--- a/waku/v2/rpc/waku_rpc_test.go
+++ b/waku/v2/rpc/waku_rpc_test.go
@@ -14,7 +14,7 @@ func TestWakuRpc(t *testing.T) {
 	n, err := node.New(context.Background(), options)
 	require.NoError(t, err)
 
-	rpc := NewWakuRpc(n, "127.0.0.1", 8080, true, true, utils.Logger().Sugar())
+	rpc := NewWakuRpc(n, "127.0.0.1", 8080, true, true, utils.Logger())
 	require.NotNil(t, rpc.server)
 	require.Equal(t, rpc.server.Addr, "127.0.0.1:8080")
 }


### PR DESCRIPTION
This is continuation of #242 where I promised to finish eradicating SugaredLogger. The changes are sprawling through many files but are largely unsurprising. I tried to preserve the status quo as much as possible with few exceptions that I'll highlight inline. I tweaked the log messages to be more in line with the proposed style. I've added few more helpers for values of interest, like *enode.Node or IP addres/port combinations.

The cleanup of the various subsystems is split into separate commits, so we could pick and chose if desired (with some additional effort).