### PR TITLE
Add option for setting the encoding/format for logs

### DIFF
--- a/waku.go
+++ b/waku.go
@@ -135,6 +135,12 @@ func main() {
 				Usage:       "Define the logging level, supported strings are: DEBUG, INFO, WARN, ERROR, DPANIC, PANIC, FATAL, and their lower-case forms.",
 				Destination: &options.LogLevel,
 			},
+			&cli.StringFlag{
+				Name:        "log-encoding",
+				Value:       "console",
+				Usage:       "Define the encoding used for the logs: console, json",
+				Destination: &options.LogEncoding,
+			},
 			&cli.BoolFlag{
 				Name:        "relay",
 				Value:       true,

--- a/waku.go
+++ b/waku.go
@@ -363,6 +363,10 @@ func main() {
 				return err
 			}
 
+			// Set encoding for logs (console, json, ...)
+			// Note that libp2p reads the encoding from GOLOG_LOG_FMT env var.
+			utils.InitLogger(options.LogEncoding)
+
 			waku.Execute(options)
 			return nil
 		},

--- a/waku/node.go
+++ b/waku/node.go
@@ -72,10 +72,6 @@ func freePort() (int, error) {
 
 // Execute starts a go-waku node with settings determined by the Options parameter
 func Execute(options Options) {
-	if options.LogEncoding != "" {
-		utils.InitLogger(options.LogEncoding)
-	}
-
 	if options.GenerateKey {
 		if err := writePrivateKeyToFile(options.KeyFile, options.Overwrite); err != nil {
 			failOnErr(err, "nodekey error")

--- a/waku/node.go
+++ b/waku/node.go
@@ -72,6 +72,10 @@ func freePort() (int, error) {
 
 // Execute starts a go-waku node with settings determined by the Options parameter
 func Execute(options Options) {
+	if options.LogEncoding != "" {
+		utils.InitLogger(options.LogEncoding)
+	}
+
 	if options.GenerateKey {
 		if err := writePrivateKeyToFile(options.KeyFile, options.Overwrite); err != nil {
 			failOnErr(err, "nodekey error")

--- a/waku/options.go
+++ b/waku/options.go
@@ -122,6 +122,7 @@ type Options struct {
 	AdvertiseAddress string
 	ShowAddresses    bool
 	LogLevel         string
+	LogEncoding      string
 
 	Websocket        WSOptions
 	Relay            RelayOptions

--- a/waku/v2/utils/logger.go
+++ b/waku/v2/utils/logger.go
@@ -22,28 +22,32 @@ func SetLogLevel(level string) error {
 // Logger creates a zap.Logger with some reasonable defaults
 func Logger() *zap.Logger {
 	if log == nil {
-		cfg := zap.Config{
-			Encoding:         "console",
-			Level:            atom,
-			OutputPaths:      []string{"stderr"},
-			ErrorOutputPaths: []string{"stderr"},
-			EncoderConfig: zapcore.EncoderConfig{
-				MessageKey:   "message",
-				LevelKey:     "level",
-				EncodeLevel:  zapcore.CapitalLevelEncoder,
-				TimeKey:      "time",
-				EncodeTime:   zapcore.ISO8601TimeEncoder,
-				NameKey:      "caller",
-				EncodeCaller: zapcore.ShortCallerEncoder,
-			},
-		}
-
-		logger, err := cfg.Build()
-		if err != nil {
-			panic("could not create logger")
-		}
-
-		log = logger.Named("gowaku")
+		InitLogger("console")
 	}
 	return log
+}
+
+func InitLogger(encoding string) {
+	cfg := zap.Config{
+		Encoding:         encoding,
+		Level:            atom,
+		OutputPaths:      []string{"stderr"},
+		ErrorOutputPaths: []string{"stderr"},
+		EncoderConfig: zapcore.EncoderConfig{
+			MessageKey:   "message",
+			LevelKey:     "level",
+			EncodeLevel:  zapcore.CapitalLevelEncoder,
+			TimeKey:      "time",
+			EncodeTime:   zapcore.ISO8601TimeEncoder,
+			NameKey:      "caller",
+			EncodeCaller: zapcore.ShortCallerEncoder,
+		},
+	}
+
+	logger, err := cfg.Build()
+	if err != nil {
+		panic("could not create logger")
+	}
+
+	log = logger.Named("gowaku")
 }

--- a/waku/v2/utils/logger.go
+++ b/waku/v2/utils/logger.go
@@ -1,6 +1,8 @@
 package utils
 
 import (
+	"fmt"
+
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -46,7 +48,7 @@ func InitLogger(encoding string) {
 
 	logger, err := cfg.Build()
 	if err != nil {
-		panic("could not create logger")
+		panic(fmt.Errorf("could not create logger: %s", err.Error()))
 	}
 
 	log = logger.Named("gowaku")


### PR DESCRIPTION
Zap supports "console" and "json" out of the box with the possibility to add other formats via [custom encoders](https://pkg.go.dev/go.uber.org/zap#RegisterEncoder).

Can be useful to address https://github.com/status-im/go-waku/pull/242#issuecomment-1140737182
