### PR TITLE
Fix race in TestConnectionStatusChanges

### DIFF
--- a/waku/v2/node/connectedness_test.go
+++ b/waku/v2/node/connectedness_test.go
@@ -14,7 +14,6 @@ import (
 )
 
 func checkConnectedness(t *testing.T, wg *sync.WaitGroup, connStatusChan chan ConnStatus, clientNode *WakuNode, node *WakuNode, nodeShouldBeConnected bool, shouldBeOnline bool, shouldHaveHistory bool, expectedPeers int) {
-	wg.Add(1)
 	defer wg.Done()
 
 	timeout := time.After(5 * time.Second)
@@ -85,6 +84,7 @@ func TestConnectionStatusChanges(t *testing.T) {
 
 	var wg sync.WaitGroup
 
+	wg.Add(1)
 	go checkConnectedness(t, &wg, connStatusChan, node1, node2, true, true, false, 1)
 
 	err = node1.DialPeer(ctx, node2.ListenAddresses()[0].String())
@@ -92,23 +92,27 @@ func TestConnectionStatusChanges(t *testing.T) {
 
 	wg.Wait()
 
+	wg.Add(1)
 	go checkConnectedness(t, &wg, connStatusChan, node1, node3, true, true, true, 2)
 
 	err = node1.DialPeer(ctx, node3.ListenAddresses()[0].String())
 	require.NoError(t, err)
 
+	wg.Add(1)
 	go checkConnectedness(t, &wg, connStatusChan, node1, node3, false, true, false, 1)
 
 	node3.Stop()
 
 	wg.Wait()
 
+	wg.Add(1)
 	go checkConnectedness(t, &wg, connStatusChan, node1, node2, false, false, false, 0)
 
 	err = node1.ClosePeerById(node2.Host().ID())
 	require.NoError(t, err)
 	wg.Wait()
 
+	wg.Add(1)
 	go checkConnectedness(t, &wg, connStatusChan, node1, node2, true, true, false, 1)
 
 	err = node1.DialPeerByID(ctx, node2.Host().ID())

--- a/waku/v2/node/connectedness_test.go
+++ b/waku/v2/node/connectedness_test.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func goCheckConnectedness(t *testing.T, wg *sync.WaitGroup, connStatusChan chan ConnStatus, clientNode *WakuNode, node *WakuNode, nodeShouldBeConnected bool, shouldBeOnline bool, shouldHaveHistory bool, expectedPeers int) {
+	goCheckConnectedness(t, wg, connStatusChan, clientNode, node, nodeShouldBeConnected, shouldBeOnline, shouldHaveHistory, expectedPeers)
+}
+
 func checkConnectedness(t *testing.T, wg *sync.WaitGroup, connStatusChan chan ConnStatus, clientNode *WakuNode, node *WakuNode, nodeShouldBeConnected bool, shouldBeOnline bool, shouldHaveHistory bool, expectedPeers int) {
 	defer wg.Done()
 
@@ -84,36 +88,31 @@ func TestConnectionStatusChanges(t *testing.T) {
 
 	var wg sync.WaitGroup
 
-	wg.Add(1)
-	go checkConnectedness(t, &wg, connStatusChan, node1, node2, true, true, false, 1)
+	goCheckConnectedness(t, &wg, connStatusChan, node1, node2, true, true, false, 1)
 
 	err = node1.DialPeer(ctx, node2.ListenAddresses()[0].String())
 	require.NoError(t, err)
 
 	wg.Wait()
 
-	wg.Add(1)
-	go checkConnectedness(t, &wg, connStatusChan, node1, node3, true, true, true, 2)
+	goCheckConnectedness(t, &wg, connStatusChan, node1, node3, true, true, true, 2)
 
 	err = node1.DialPeer(ctx, node3.ListenAddresses()[0].String())
 	require.NoError(t, err)
 
-	wg.Add(1)
-	go checkConnectedness(t, &wg, connStatusChan, node1, node3, false, true, false, 1)
+	goCheckConnectedness(t, &wg, connStatusChan, node1, node3, false, true, false, 1)
 
 	node3.Stop()
 
 	wg.Wait()
 
-	wg.Add(1)
-	go checkConnectedness(t, &wg, connStatusChan, node1, node2, false, false, false, 0)
+	goCheckConnectedness(t, &wg, connStatusChan, node1, node2, false, false, false, 0)
 
 	err = node1.ClosePeerById(node2.Host().ID())
 	require.NoError(t, err)
 	wg.Wait()
 
-	wg.Add(1)
-	go checkConnectedness(t, &wg, connStatusChan, node1, node2, true, true, false, 1)
+	goCheckConnectedness(t, &wg, connStatusChan, node1, node2, true, true, false, 1)
 
 	err = node1.DialPeerByID(ctx, node2.Host().ID())
 	require.NoError(t, err)

--- a/waku/v2/node/connectedness_test.go
+++ b/waku/v2/node/connectedness_test.go
@@ -14,7 +14,8 @@ import (
 )
 
 func goCheckConnectedness(t *testing.T, wg *sync.WaitGroup, connStatusChan chan ConnStatus, clientNode *WakuNode, node *WakuNode, nodeShouldBeConnected bool, shouldBeOnline bool, shouldHaveHistory bool, expectedPeers int) {
-	goCheckConnectedness(t, wg, connStatusChan, clientNode, node, nodeShouldBeConnected, shouldBeOnline, shouldHaveHistory, expectedPeers)
+	wg.Add(1)
+	go checkConnectedness(t, wg, connStatusChan, clientNode, node, nodeShouldBeConnected, shouldBeOnline, shouldHaveHistory, expectedPeers)
 }
 
 func checkConnectedness(t *testing.T, wg *sync.WaitGroup, connStatusChan chan ConnStatus, clientNode *WakuNode, node *WakuNode, nodeShouldBeConnected bool, shouldBeOnline bool, shouldHaveHistory bool, expectedPeers int) {


### PR DESCRIPTION
TestConnectionStatusChanges has a race in it because it's adding to a WaitGroup inside the goroutines managed by the WaitGroup (race detector output below). Oddly enough I stumbled upon it trying to debug flakiness of Test5000 that we were seeing in our test runs. I observed that when the test succeeds it runs in less than 5s locally, but often it times out given even a minute to complete. It would be the subscriber goroutines that would timeout consuming some fraction of the 5000 messages. It seemed something is racing somewhere. Surprisingly race detector didn't reveal anything when running just Test5000, but it tripped when running the test suite for the whole package, pointing at TestConnectionStatusChanges. The error there is fairly clear, fixed here. But I'm not quite sure how does that trip up Test5000, but it seems to fix it too. It suggests there was something global that was locking up, but I have no idea what.

```
% go test ./waku/v2/node --race
2022-06-07T13:55:08.324-0400    WARN    gowaku  logger not yet initialized
2022-06-07T13:55:08.608-0400    INFO    gowaku.node2    Version details         {"commit": ""}
2022-06-07T13:55:08.609-0400    INFO    gowaku.node2.relay      Relay protocol started
2022-06-07T13:55:08.609-0400    INFO    gowaku.node2.relay      subscribing to topic    {"topic": "/waku/2/default-waku/proto"}
2022-06-07T13:55:08.951-0400    INFO    gowaku.node2    Version details         {"commit": ""}
2022-06-07T13:55:08.952-0400    INFO    gowaku.node2.relay      Relay protocol started
2022-06-07T13:55:08.952-0400    INFO    gowaku.node2.relay      subscribing to topic    {"topic": "/waku/2/default-waku/proto"}
2022-06-07T13:55:09.276-0400    INFO    gowaku.node2    Version details         {"commit": ""}
2022-06-07T13:55:09.276-0400    INFO    gowaku.node2.store      Store protocol started
2022-06-07T13:55:09.277-0400    INFO    gowaku.node2.relay      Relay protocol started
2022-06-07T13:55:09.277-0400    INFO    gowaku.node2.relay      subscribing to topic    {"topic": "/waku/2/default-waku/proto"}
2022-06-07T13:55:09.288-0400    INFO    gowaku.node2    peer connected  {"peer": "QmPvpcZxEoiLNA3PANZwwAYqiRK5oVwBcdoPFy2fxwhxzL"}
2022-06-07T13:55:09.289-0400    INFO    gowaku.node2    peer connected  {"peer": "QmeF9UmW275pGwrHajpkV2z9bSd9vkUsjvrXspn5KMPq43"}
==================
WARNING: DATA RACE
Write at 0x00c001ccb174 by goroutine 27:
  internal/race.Write()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/internal/race/race.go:42 +0xec
  sync.(*WaitGroup).Wait()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/sync/waitgroup.go:128 +0xe0
  github.com/status-im/go-waku/waku/v2/node.TestConnectionStatusChanges()
      /Users/martin/go/go-waku/waku/v2/node/connectedness_test.go:93 +0x924
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1259 +0x198

Previous read at 0x00c001ccb174 by goroutine 229:
  internal/race.Read()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/internal/race/race.go:38 +0x130
  sync.(*WaitGroup).Add()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/sync/waitgroup.go:71 +0x124
  github.com/status-im/go-waku/waku/v2/node.checkConnectedness()
      /Users/martin/go/go-waku/waku/v2/node/connectedness_test.go:17 +0x40

Goroutine 27 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1306 +0x5b8
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1598 +0xac
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1259 +0x198
  testing.runTests()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1596 +0x780
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1504 +0x928
  main.main()
      _testmain.go:75 +0x288

Goroutine 229 (running) created at:
  github.com/status-im/go-waku/waku/v2/node.TestConnectionStatusChanges()
      /Users/martin/go/go-waku/waku/v2/node/connectedness_test.go:88 +0x87c
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1259 +0x198
==================
2022-06-07T13:55:09.301-0400    INFO    gowaku.node2    peer connected  {"peer": "QmPvpcZxEoiLNA3PANZwwAYqiRK5oVwBcdoPFy2fxwhxzL"}
2022-06-07T13:55:09.301-0400    INFO    gowaku.node2    peer connected  {"peer": "QmVxB7NZJMPra4X2j7oNn6QLc6VeyL7QjNaY5a353Wm3Cb"}
2022-06-07T13:55:09.304-0400    INFO    gowaku.node2    peer disconnected       {"peer": "QmPvpcZxEoiLNA3PANZwwAYqiRK5oVwBcdoPFy2fxwhxzL"}
2022-06-07T13:55:09.304-0400    INFO    gowaku.node2    peer disconnected       {"peer": "QmVxB7NZJMPra4X2j7oNn6QLc6VeyL7QjNaY5a353Wm3Cb"}
2022-06-07T13:55:09.305-0400    INFO    gowaku.node2    peer disconnected       {"peer": "QmeF9UmW275pGwrHajpkV2z9bSd9vkUsjvrXspn5KMPq43"}
2022-06-07T13:55:09.305-0400    INFO    gowaku.node2    peer disconnected       {"peer": "QmPvpcZxEoiLNA3PANZwwAYqiRK5oVwBcdoPFy2fxwhxzL"}
2022-06-07T13:55:09.315-0400    INFO    gowaku.node2    peer connected  {"peer": "QmeF9UmW275pGwrHajpkV2z9bSd9vkUsjvrXspn5KMPq43"}
2022-06-07T13:55:09.315-0400    INFO    gowaku.node2    peer connected  {"peer": "QmPvpcZxEoiLNA3PANZwwAYqiRK5oVwBcdoPFy2fxwhxzL"}
2022-06-07T13:55:09.315-0400    INFO    gowaku.node2    peer connected  {"peer": "QmPvpcZxEoiLNA3PANZwwAYqiRK5oVwBcdoPFy2fxwhxzL"}
2022-06-07T13:55:09.316-0400    INFO    gowaku.node2    peer disconnected       {"peer": "QmPvpcZxEoiLNA3PANZwwAYqiRK5oVwBcdoPFy2fxwhxzL"}
--- FAIL: TestConnectionStatusChanges (0.99s)
    testing.go:1152: race detected during execution of test
2022-06-07T13:55:11.700-0400    INFO    gowaku.node2    Version details         {"commit": ""}
2022-06-07T13:55:11.701-0400    INFO    gowaku.node2.relay      Relay protocol started
2022-06-07T13:55:11.701-0400    INFO    gowaku.node2.relay      subscribing to topic    {"topic": "/waku/2/default-waku/proto"}
2022-06-07T13:55:11.702-0400    INFO    gowaku.node2    listening       {"multiaddr": ["/ip4/100.111.27.5/tcp/52860/p2p/16Uiu2HAmDJqFyuxN141p5LYEvZ764BXZuFtUbVn3ozMrFN2oNhbQ"], "enr": "enr:-Iu4QDSRUTS34eKPW_xI1Oq-t_E1vhlkffiw_0iBLqsryzJQWbBVT8n95rMbUE4zC8UFcBe7jrkkMbz0mLBW-imKbIOAgmlkgnY0gmlwhGRvGwWJc2VjcDI1NmsxoQMJscp639_tTKIlSLfHDWqGrIlqNaSadxAALo6ggfisc4N0Y3CCznyFd2FrdTIB", "ip": "100.111.27.5:52860"}
2022-06-07T13:55:11.703-0400    INFO    gowaku.node2    listening       {"multiaddr": ["/ip4/127.0.0.1/tcp/52860/p2p/16Uiu2HAmDJqFyuxN141p5LYEvZ764BXZuFtUbVn3ozMrFN2oNhbQ"], "enr": "enr:-Iu4QEN7yRMfsyyyq5FYaQRTF62RXYEoFnV-5r0AURP-drZycXizJSejn6nYpKRZcchkhvsghn0lCI3uBjdn6QIjltuAgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQMJscp639_tTKIlSLfHDWqGrIlqNaSadxAALo6ggfisc4N0Y3CCznyFd2FrdTIB", "ip": "127.0.0.1:52860"}
2022-06-07T13:55:11.717-0400    INFO    gowaku.node2    Version details         {"commit": ""}
2022-06-07T13:55:11.718-0400    INFO    gowaku.node2.relay      Relay protocol started
2022-06-07T13:55:11.718-0400    INFO    gowaku.node2.relay      subscribing to topic    {"topic": "/waku/2/default-waku/proto"}
2022-06-07T13:55:11.718-0400    INFO    gowaku.node2    listening       {"multiaddr": ["/ip4/100.111.27.5/tcp/52861/p2p/16Uiu2HAm7pAK3eLaeGDGuuVpSZExYpKDnSd64UEC6EU6SXCTP3Qw"], "enr": "enr:-Iu4QP1sMPRZD_nT2ZvWIl7yyEq9746IfqDSZCCcy0TvklFiHcAVB9tRbEdso7yDUQbDcgCGGwhZNHDniiAckKW4RpqAgmlkgnY0gmlwhGRvGwWJc2VjcDI1NmsxoQK4Dw5StrHQ_KuWN_xUREuxrgDP5FYEdWrDe47pZ_DRpIN0Y3CCzn2Fd2FrdTIB", "ip": "100.111.27.5:52861"}
2022-06-07T13:55:11.719-0400    INFO    gowaku.node2    listening       {"multiaddr": ["/ip4/127.0.0.1/tcp/52861/p2p/16Uiu2HAm7pAK3eLaeGDGuuVpSZExYpKDnSd64UEC6EU6SXCTP3Qw"], "enr": "enr:-Iu4QH_ePOPTnin0WV0KBw5o6M0wdIGjVvxp8wnCFvJk1VzkPsTpOmFekZID0NX0PyQN6sm62XalF60pNLLMT4G-vPWAgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQK4Dw5StrHQ_KuWN_xUREuxrgDP5FYEdWrDe47pZ_DRpIN0Y3CCzn2Fd2FrdTIB", "ip": "127.0.0.1:52861"}
2022-06-07T13:55:11.733-0400    INFO    gowaku.node2    Version details         {"commit": ""}
2022-06-07T13:55:11.733-0400    INFO    gowaku.node2.relay      Relay protocol started
2022-06-07T13:55:11.734-0400    INFO    gowaku.node2.relay      subscribing to topic    {"topic": "/waku/2/default-waku/proto"}
2022-06-07T13:55:11.734-0400    INFO    gowaku.node2    listening       {"multiaddr": ["/ip4/100.111.27.5/tcp/52862/p2p/16Uiu2HAkzUWtgFWTDo6ZcaYKCURNSjB4wy2TAdwRgh8NrHC3AjTD"], "enr": "enr:-Iu4QMoG5cWY9t49EHt0EVhZnp23T6xQIPna7f78w-mJuNnRanUCygWYNr5zeWx-68qUqjkjoMmdE17odSRRTpecMRuAgmlkgnY0gmlwhGRvGwWJc2VjcDI1NmsxoQJLBOanW9dSTU2LifZ5925CUO6zrhFSpOei0x3iVmSqwIN0Y3CCzn6Fd2FrdTIB", "ip": "100.111.27.5:52862"}
2022-06-07T13:55:11.734-0400    INFO    gowaku.node2    listening       {"multiaddr": ["/ip4/127.0.0.1/tcp/52862/p2p/16Uiu2HAkzUWtgFWTDo6ZcaYKCURNSjB4wy2TAdwRgh8NrHC3AjTD"], "enr": "enr:-Iu4QFBMTMAWwPVPlUN8K9d8QeV-tfaK1I3R--FXKUoc66DmHbXXwxqJRL1dR4Ex1XEJxZWRqfFF7DpZyYlDmJs4cAiAgmlkgnY0gmlwhH8AAAGJc2VjcDI1NmsxoQJLBOanW9dSTU2LifZ5925CUO6zrhFSpOei0x3iVmSqwIN0Y3CCzn6Fd2FrdTIB", "ip": "127.0.0.1:52862"}
2022-06-07T13:55:11.748-0400    INFO    gowaku.node2    peer connected  {"peer": "16Uiu2HAkzUWtgFWTDo6ZcaYKCURNSjB4wy2TAdwRgh8NrHC3AjTD"}
2022-06-07T13:55:11.748-0400    INFO    gowaku.node2    peer connected  {"peer": "16Uiu2HAm7pAK3eLaeGDGuuVpSZExYpKDnSd64UEC6EU6SXCTP3Qw"}
2022-06-07T13:55:14.110-0400    INFO    gowaku.node2    peer disconnected       {"peer": "16Uiu2HAm7pAK3eLaeGDGuuVpSZExYpKDnSd64UEC6EU6SXCTP3Qw"}
2022-06-07T13:55:14.111-0400    INFO    gowaku.node2    peer disconnected       {"peer": "16Uiu2HAkzUWtgFWTDo6ZcaYKCURNSjB4wy2TAdwRgh8NrHC3AjTD"}
FAIL
FAIL    github.com/status-im/go-waku/waku/v2/node       6.115s
FAIL
```

Fixes xmtp/go-waku#16