### PR TITLE
Fix races in filter protocol and tests

### DIFF
--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -36,6 +36,17 @@ func (sub *Subscribers) Append(s Subscriber) int {
 	return len(sub.subscribers)
 }
 
+func (subs *Subscribers) SubscriberHasContentTopic(sub Subscriber, topic string) bool {
+	subs.Lock()
+	defer subs.Unlock()
+	for _, filter := range sub.filter.ContentFilters {
+		if filter.ContentTopic == topic {
+			return true
+		}
+	}
+	return false
+}
+
 func (sub *Subscribers) Items() <-chan Subscriber {
 	c := make(chan Subscriber)
 
@@ -57,6 +68,13 @@ func (sub *Subscribers) Length() int {
 	defer sub.RUnlock()
 
 	return len(sub.subscribers)
+}
+
+func (sub *Subscribers) IsFailedPeer(peerID peer.ID) bool {
+	sub.Lock()
+	defer sub.Unlock()
+	_, ok := sub.failedPeers[peerID]
+	return ok
 }
 
 func (sub *Subscribers) FlagAsSuccess(peerID peer.ID) {

--- a/waku/v2/protocol/filter/filter_subscribers.go
+++ b/waku/v2/protocol/filter/filter_subscribers.go
@@ -37,8 +37,8 @@ func (sub *Subscribers) Append(s Subscriber) int {
 }
 
 func (subs *Subscribers) SubscriberHasContentTopic(sub Subscriber, topic string) bool {
-	subs.Lock()
-	defer subs.Unlock()
+	subs.RLock()
+	defer subs.RUnlock()
 	for _, filter := range sub.filter.ContentFilters {
 		if filter.ContentTopic == topic {
 			return true
@@ -71,8 +71,8 @@ func (sub *Subscribers) Length() int {
 }
 
 func (sub *Subscribers) IsFailedPeer(peerID peer.ID) bool {
-	sub.Lock()
-	defer sub.Unlock()
+	sub.RLock()
+	defer sub.RUnlock()
 	_, ok := sub.failedPeers[peerID]
 	return ok
 }

--- a/waku/v2/protocol/filter/waku_filter.go
+++ b/waku/v2/protocol/filter/waku_filter.go
@@ -199,21 +199,17 @@ func (wf *WakuFilter) FilterListener() {
 				continue
 			}
 
-			for _, filter := range subscriber.filter.ContentFilters {
-				if msg.ContentTopic == filter.ContentTopic {
-					logger.Info("found matching content topic", zap.Stringer("filter", filter))
-					// Do a message push to light node
-					logger.Info("pushing message to light node")
-					g.Go(func() (err error) {
-						err = wf.pushMessage(subscriber, msg)
-						if err != nil {
-							logger.Error("pushing message", zap.Error(err))
-						}
-						return err
-					})
-					// Break if we have found a match
-					break
-				}
+			if wf.subscribers.SubscriberHasContentTopic(subscriber, msg.ContentTopic) {
+				logger.Info("found matching content topic", zap.String("contentTopic", msg.ContentTopic))
+				// Do a message push to light node
+				logger.Info("pushing message to light node")
+				g.Go(func() (err error) {
+					err = wf.pushMessage(subscriber, msg)
+					if err != nil {
+						logger.Error("pushing message", zap.Error(err))
+					}
+					return err
+				})
 			}
 		}
 

--- a/waku/v2/protocol/filter/waku_filter_test.go
+++ b/waku/v2/protocol/filter/waku_filter_test.go
@@ -175,8 +175,7 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 	// Sleep to make sure the filter is subscribed
 	time.Sleep(2 * time.Second)
 
-	_, ok := node2Filter.subscribers.failedPeers[host1.ID()]
-	require.True(t, ok)
+	require.True(t, node2Filter.subscribers.IsFailedPeer(host1.ID()))
 
 	var wg sync.WaitGroup
 
@@ -187,8 +186,7 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 		require.Equal(t, contentFilter.ContentTopics[0], env.Message().GetContentTopic())
 
 		// Failure is removed
-		_, ok := node2Filter.subscribers.failedPeers[host1.ID()]
-		require.False(t, ok)
+		require.False(t, node2Filter.subscribers.IsFailedPeer(host1.ID()))
 
 	}()
 
@@ -207,8 +205,7 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 
 	// TODO: find out how to eliminate this sleep
 	time.Sleep(1 * time.Second)
-	_, ok = node2Filter.subscribers.failedPeers[host1.ID()]
-	require.True(t, ok)
+	require.True(t, node2Filter.subscribers.IsFailedPeer(host1.ID()))
 
 	time.Sleep(3 * time.Second)
 
@@ -216,8 +213,7 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 	require.NoError(t, err)
 
 	time.Sleep(1 * time.Second)
-	_, ok = node2Filter.subscribers.failedPeers[host1.ID()]
-	require.False(t, ok) // Failed peer has been removed
+	require.False(t, node2Filter.subscribers.IsFailedPeer(host1.ID())) // Failed peer has been removed
 
 	for subscriber := range node2Filter.subscribers.Items() {
 		if subscriber.peer == node1.h.ID() {


### PR DESCRIPTION
This is a follow up to #257, which did not fix the flakiness of Test5000 for us. Trying to run the entire test suite under the race detector uncovered some more races in the filter protocol (see below). One race was from unsafe accesses from the test,  another race was in the protocol implementation where the FilterListener was racing with the onRequest handler over a subscriber's content filters.

```
% go test ./waku/v2/protocol/filter --race --count=1
2022-06-09T11:03:01.758-0400    INFO    gowaku  selecting peer  {"error": "no suitable peers found"}
2022-06-09T11:03:01.758-0400    INFO    gowaku  selecting peer  {"error": "no suitable peers found"}
2022-06-09T11:03:01.901-0400    INFO    gowaku.filter   filter protocol started {"fullNode": false}
2022-06-09T11:03:02.144-0400    INFO    gowaku.relay    Relay protocol started
2022-06-09T11:03:02.144-0400    INFO    gowaku.relay    subscribing to topic    {"topic": "/waku/2/go/filter/test"}
2022-06-09T11:03:02.145-0400    INFO    gowaku.filter   filter protocol started {"fullNode": true}
2022-06-09T11:03:02.158-0400    INFO    gowaku.filter   sending filterRPC       {"fullNode": false, "rpc": "requestId:\"8353c49de9010be3ab40f52c0165b9a1cb98ede4d7ddf67efaea2714b8ab36a4\" request:<subscribe:true topic:\"/waku/2/go/filter/test\" contentFilters:<contentTopic:\"TopicA\" > > "}
2022-06-09T11:03:02.159-0400    INFO    gowaku.filter   received request        {"fullNode": true, "peer": "QmUp443u97PBgc4N75S3rt4f6utPxAjBuCpvw9XWfDQy7E"}
2022-06-09T11:03:02.159-0400    INFO    gowaku.filter   adding subscriber       {"fullNode": true, "peer": "QmUp443u97PBgc4N75S3rt4f6utPxAjBuCpvw9XWfDQy7E"}
2022-06-09T11:03:04.163-0400    INFO    gowaku.filter   found matching content topic    {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" ", "subscriber": "QmUp443u97PBgc4N75S3rt4f6utPxAjBuCpvw9XWfDQy7E", "filter": "contentTopic:\"TopicA\" "}
2022-06-09T11:03:04.164-0400    INFO    gowaku.filter   pushing message to light node   {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" ", "subscriber": "QmUp443u97PBgc4N75S3rt4f6utPxAjBuCpvw9XWfDQy7E"}
2022-06-09T11:03:04.167-0400    INFO    gowaku.filter   received request        {"fullNode": false, "peer": "QmTkApSnRnwMAtBaw551FQu7tr8Z2hNsCYaHGT4d9PAxaw"}
2022-06-09T11:03:04.167-0400    INFO    gowaku.filter   received a message push {"fullNode": false, "peer": "QmTkApSnRnwMAtBaw551FQu7tr8Z2hNsCYaHGT4d9PAxaw", "messages": 1}
2022-06-09T11:03:05.173-0400    INFO    gowaku.filter   received request        {"fullNode": true, "peer": "QmUp443u97PBgc4N75S3rt4f6utPxAjBuCpvw9XWfDQy7E"}
==================
WARNING: DATA RACE
Write at 0x00c000010090 by goroutine 129:
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*Subscribers).RemoveContentFilters()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/filter_subscribers.go:113 +0x804
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*WakuFilter).onRequest()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:135 +0x71c
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*WakuFilter).onRequest-fm()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:99 +0x50
  github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandlerMatch.func1()
      /Users/martin/go/pkg/mod/github.com/libp2p/go-libp2p@v0.20.0/p2p/host/basic/basic_host.go:582 +0x88

Previous read at 0x00c000010090 by goroutine 160:
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*WakuFilter).FilterListener.func1()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:202 +0x61c
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*WakuFilter).FilterListener()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:224 +0xfc

Goroutine 129 (running) created at:
  github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler()
      /Users/martin/go/pkg/mod/github.com/libp2p/go-libp2p@v0.20.0/p2p/host/basic/basic_host.go:411 +0x6e8
  github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler-fm()
      /Users/martin/go/pkg/mod/github.com/libp2p/go-libp2p@v0.20.0/p2p/host/basic/basic_host.go:368 +0x50
  github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).start.func1.1()
      /Users/martin/go/pkg/mod/github.com/libp2p/go-libp2p@v0.20.0/p2p/net/swarm/swarm_conn.go:133 +0x10c

Goroutine 160 (running) created at:
  github.com/status-im/go-waku/waku/v2/protocol/filter.NewWakuFilter()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:93 +0xa48
  github.com/status-im/go-waku/waku/v2/protocol/filter.TestWakuFilter()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter_test.go:72 +0x2b4
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1259 +0x198
==================
2022-06-09T11:03:05.173-0400    INFO    gowaku.filter   removing subscriber     {"fullNode": true, "peer": "QmUp443u97PBgc4N75S3rt4f6utPxAjBuCpvw9XWfDQy7E"}
--- FAIL: TestWakuFilter (4.42s)
    testing.go:1152: race detected during execution of test
2022-06-09T11:03:06.453-0400    INFO    gowaku.filter   filter protocol started {"fullNode": false}
2022-06-09T11:03:06.599-0400    INFO    gowaku.relay    Relay protocol started
2022-06-09T11:03:06.599-0400    INFO    gowaku.relay    subscribing to topic    {"topic": "/waku/2/go/filter/test"}
2022-06-09T11:03:06.599-0400    INFO    gowaku.filter   filter protocol started {"fullNode": true}
2022-06-09T11:03:06.613-0400    INFO    gowaku.filter   sending filterRPC       {"fullNode": false, "rpc": "requestId:\"349e1432ff34506d92fb98f7750c6e782b548bc47780dc100f69f91586ebce4b\" request:<subscribe:true topic:\"/waku/2/go/filter/test\" contentFilters:<contentTopic:\"TopicA\" > > "}
2022-06-09T11:03:06.613-0400    INFO    gowaku.filter   received request        {"fullNode": true, "peer": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP"}
2022-06-09T11:03:06.613-0400    INFO    gowaku.filter   adding subscriber       {"fullNode": true, "peer": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP"}
2022-06-09T11:03:08.614-0400    INFO    gowaku.filter   found matching content topic    {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" ", "subscriber": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP", "filter": "contentTopic:\"TopicA\" "}
2022-06-09T11:03:08.614-0400    INFO    gowaku.filter   pushing message to light node   {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" ", "subscriber": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP"}
2022-06-09T11:03:08.616-0400    INFO    gowaku.filter   received request        {"fullNode": false, "peer": "QmThvqGPAzb5mDRysWADzgtR8GYTzLadsPh2pppZcVCQMD"}
2022-06-09T11:03:08.616-0400    INFO    gowaku.filter   received a message push {"fullNode": false, "peer": "QmThvqGPAzb5mDRysWADzgtR8GYTzLadsPh2pppZcVCQMD", "messages": 1}
2022-06-09T11:03:09.618-0400    INFO    gowaku.filter   found matching content topic    {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" timestamp:1 ", "subscriber": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP", "filter": "contentTopic:\"TopicA\" "}
2022-06-09T11:03:09.618-0400    INFO    gowaku.filter   pushing message to light node   {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" timestamp:1 ", "subscriber": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP"}
2022-06-09T11:03:09.619-0400    ERROR   gowaku.filter   connecting to peer      {"fullNode": true, "peer": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP", "error": "failed to dial QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP:\n  * [/ip4/127.0.0.1/tcp/51492] dial tcp4 127.0.0.1:51492: connect: connection refused\n  * [/ip4/100.111.27.5/tcp/51492] dial tcp4 100.111.27.5:51492: connect: connection refused"}
2022-06-09T11:03:09.619-0400    ERROR   gowaku.filter   pushing message {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" timestamp:1 ", "subscriber": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP", "error": "failed to dial QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP:\n  * [/ip4/127.0.0.1/tcp/51492] dial tcp4 127.0.0.1:51492: connect: connection refused\n  * [/ip4/100.111.27.5/tcp/51492] dial tcp4 100.111.27.5:51492: connect: connection refused"}
2022-06-09T11:03:09.619-0400    ERROR   gowaku.filter   handling message        {"fullNode": true, "error": "failed to dial QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP:\n  * [/ip4/127.0.0.1/tcp/51492] dial tcp4 127.0.0.1:51492: connect: connection refused\n  * [/ip4/100.111.27.5/tcp/51492] dial tcp4 100.111.27.5:51492: connect: connection refused"}
==================
WARNING: DATA RACE
Read at 0x00c001cc6180 by goroutine 132:
  runtime.mapaccess1_faststr()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/runtime/map_faststr.go:12 +0x45c
  github.com/status-im/go-waku/waku/v2/protocol/filter.TestWakuFilterPeerFailure()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter_test.go:210 +0xe24
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1259 +0x198

Previous write at 0x00c001cc6180 by goroutine 102:
  runtime.mapaccess2_faststr()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/runtime/map_faststr.go:107 +0x48c
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*Subscribers).FlagAsFailure()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/filter_subscribers.go:91 +0x1c0
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*WakuFilter).pushMessage()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:153 +0x4b8
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*WakuFilter).FilterListener.func1.1()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:208 +0x98
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/martin/go/pkg/mod/golang.org/x/sync@v0.0.0-20220513210516-0976fa681c29/errgroup/errgroup.go:74 +0x60

Goroutine 132 (running) created at:
  testing.(*T).Run()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1306 +0x5b8
  testing.runTests.func1()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1598 +0xac
  testing.tRunner()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1259 +0x198
  testing.runTests()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1596 +0x780
  testing.(*M).Run()
      /opt/homebrew/Cellar/go/1.17.5/libexec/src/testing/testing.go:1504 +0x928
  main.main()
      _testmain.go:49 +0x288

Goroutine 102 (finished) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/martin/go/pkg/mod/golang.org/x/sync@v0.0.0-20220513210516-0976fa681c29/errgroup/errgroup.go:71 +0xac
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*WakuFilter).FilterListener.func1()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:207 +0x92c
  github.com/status-im/go-waku/waku/v2/protocol/filter.(*WakuFilter).FilterListener()
      /Users/martin/go/go-waku/waku/v2/protocol/filter/waku_filter.go:224 +0xfc
==================
2022-06-09T11:03:13.620-0400    INFO    gowaku.filter   found matching content topic    {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" timestamp:2 ", "subscriber": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP", "filter": "contentTopic:\"TopicA\" "}
2022-06-09T11:03:13.620-0400    INFO    gowaku.filter   pushing message to light node   {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" timestamp:2 ", "subscriber": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP"}
2022-06-09T11:03:13.621-0400    ERROR   gowaku.filter   connecting to peer      {"fullNode": true, "peer": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP", "error": "failed to dial QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP:\n  * [/ip4/100.111.27.5/tcp/51492] dial backoff\n  * [/ip4/127.0.0.1/tcp/51492] dial backoff"}
2022-06-09T11:03:13.621-0400    ERROR   gowaku.filter   pushing message {"fullNode": true, "message": "payload:\"\\001\\002\\003\" contentTopic:\"TopicA\" timestamp:2 ", "subscriber": "QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP", "error": "failed to dial QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP:\n  * [/ip4/100.111.27.5/tcp/51492] dial backoff\n  * [/ip4/127.0.0.1/tcp/51492] dial backoff"}
2022-06-09T11:03:13.621-0400    ERROR   gowaku.filter   handling message        {"fullNode": true, "error": "failed to dial QmTvVuAmPHnd552EvJeFZVjDKw1AtsoE7x4ekrQKBoEqXP:\n  * [/ip4/100.111.27.5/tcp/51492] dial backoff\n  * [/ip4/127.0.0.1/tcp/51492] dial backoff"}
--- FAIL: TestWakuFilterPeerFailure (8.45s)
    testing.go:1152: race detected during execution of test
FAIL
FAIL    github.com/status-im/go-waku/waku/v2/protocol/filter    13.340s
```