### PR TITLE
Fix filter deadlock

### DIFF
--- a/waku/v2/protocol/filter/waku_filter_test.go
+++ b/waku/v2/protocol/filter/waku_filter_test.go
@@ -215,7 +215,7 @@ func TestWakuFilterPeerFailure(t *testing.T) {
 	time.Sleep(1 * time.Second)
 	require.False(t, node2Filter.subscribers.IsFailedPeer(host1.ID())) // Failed peer has been removed
 
-	for subscriber := range node2Filter.subscribers.Items() {
+	for subscriber := range node2Filter.subscribers.Items(nil) {
 		if subscriber.peer == node1.h.ID() {
 			require.Fail(t, "Subscriber should not exist")
 		}


### PR DESCRIPTION
status-im#260 introduced a subtle recursive read lock issue. Even though `SubscriptionHasContentTopic` runs in a different goroutine than the goroutine created bye `Items()`, that's why an RLock was needed there, it creates a deadlock in its interaction with `onRequest` that attempts to acquire a full lock when adding a subscriber. This creates the situation [described in the docs](https://pkg.go.dev/sync#RWMutex):

> If a goroutine holds a RWMutex for reading and another goroutine might call Lock, no goroutine should expect to be able to acquire a read lock until the initial read lock is released. In particular, this prohibits recursive read locking. This is to ensure that the lock eventually becomes available; a blocked Lock call excludes new readers from acquiring the lock.

So Items() grabs the RLock, an incoming request attempts to grab full Lock which makes subsequent RLock calls block until Items() completes. So SubscriptionHasContentTopic starts blocking and prevents Items() from completing (since they are synchronized through an unbuffered channel).

The solution here is what I proposed in the original PR as [maybe a better fix](https://github.com/status-im/go-waku/pull/260#discussion_r893739405). The idea is to extend `Items()` to do the topic filtering for us, that eliminates the need to iterate over subscription filters and consequently the need for RLock in FilterListener. The resulting behavior should be the same with one small caveat that I'll point out inline.
