### PR TITLE
Fix logging.From panic

### DIFF
--- a/logging/context.go
+++ b/logging/context.go
@@ -9,7 +9,7 @@ import (
 var logKey = &struct{}{}
 
 // From allows retrieving the Logger from a Context.
-// Returns default logger if Context does not have one.
+// Returns nil if Context does not have one.
 func From(ctx context.Context) *zap.Logger {
 	logger, _ := ctx.Value(logKey).(*zap.Logger)
 	return logger

--- a/logging/context.go
+++ b/logging/context.go
@@ -8,9 +8,11 @@ import (
 
 var logKey = &struct{}{}
 
-// From allows retrieving the Logger from a Context
+// From allows retrieving the Logger from a Context.
+// Returns default logger if Context does not have one.
 func From(ctx context.Context) *zap.Logger {
-	return ctx.Value(logKey).(*zap.Logger)
+	logger, _ := ctx.Value(logKey).(*zap.Logger)
+	return logger
 }
 
 // With associates a Logger with a Context to allow passing

--- a/logging/context_test.go
+++ b/logging/context_test.go
@@ -1,0 +1,21 @@
+package logging
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func Test_EmptyContext(t *testing.T) {
+	logger := From(context.Background())
+	require.Nil(t, logger)
+}
+
+func Test_With(t *testing.T) {
+	logger, err := zap.NewDevelopment()
+	require.NoError(t, err)
+	ctx := With(context.Background(), logger)
+	require.Equal(t, logger, From(ctx))
+}


### PR DESCRIPTION
The type assertion in `logging.From` blows up if the `Context` does not have a logger. This PR fixes the assertion and returns nil if there's no logger. Added tests to confirm the fix.