### PR TITLE
Close addrChan in the writer goroutine

### DIFF
--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -211,6 +211,7 @@ func (w *WakuNode) checkForAddressChanges() {
 	for {
 		select {
 		case <-w.quit:
+			close(w.addrChan)
 			return
 		case <-first:
 			w.log.Info("listening", logging.MultiAddrs("multiaddr", addrs...))
@@ -322,7 +323,6 @@ func (w *WakuNode) Stop() {
 	defer w.cancel()
 
 	close(w.quit)
-	close(w.addrChan)
 
 	w.bcaster.Close()
 


### PR DESCRIPTION
Sometimes during tear down the node will panic with:
```
panic: send on closed channel

goroutine 10178 [running]:
github.com/status-im/go-waku/waku/v2/node.(*WakuNode).checkForAddressChanges(0x14000824a00)
	/Users/snormore/go/pkg/mod/github.com/xmtp/go-waku@v0.0.0-20220726180454-7710a1d099a9/waku/v2/node/wakunode2.go:234 +0x470
created by github.com/status-im/go-waku/waku/v2/node.New
	/Users/snormore/go/pkg/mod/github.com/xmtp/go-waku@v0.0.0-20220726180454-7710a1d099a9/waku/v2/node/wakunode2.go:187 +0xe34
```

It looks like `addrChan` is being sent to after it's been closed in `Stop`, so this PR updates it to close `addrChan` in the same goroutine as it's being written/sent to, rather than in `Stop`.