### PR TITLE
Clean up ENR localNode DB

### DIFF
--- a/waku/v2/node/localnode.go
+++ b/waku/v2/node/localnode.go
@@ -226,7 +226,11 @@ func (w *WakuNode) setupENR(addrs []ma.Multiaddr) error {
 			return err
 		} else {
 			if w.localNode == nil || w.localNode.Node().String() != localNode.Node().String() {
+				existingLocalNode := w.localNode
 				w.localNode = localNode
+				if existingLocalNode != nil {
+					existingLocalNode.Database().Close()
+				}
 				w.log.Info("enr record", logging.ENode("enr", w.localNode.Node()))
 			}
 		}

--- a/waku/v2/node/wakunode2.go
+++ b/waku/v2/node/wakunode2.go
@@ -346,6 +346,10 @@ func (w *WakuNode) Stop() {
 	w.host.Close()
 
 	w.wg.Wait()
+
+	if w.localNode != nil {
+		w.localNode.Database().Close()
+	}
 }
 
 // Host returns the libp2p Host used by the WakuNode


### PR DESCRIPTION
Close ENR localnode DB during node tear down and address change, otherwise memory usage accrues pretty quickly if you're creating and tearing down a bunch of nodes in process.