### PR TITLE
feat: add flag to set wss port

### DIFF
--- a/waku.go
+++ b/waku.go
@@ -44,7 +44,14 @@ func main() {
 			Aliases:     []string{"ws-port"},
 			Value:       60001,
 			Usage:       "Libp2p TCP listening port for websocket connection (0 for random)",
-			Destination: &options.Websocket.Port,
+			Destination: &options.Websocket.WSPort,
+		},
+		&cli.IntFlag{
+			Name:        "websocket-secure-port",
+			Aliases:     []string{"wss-port"},
+			Value:       6443,
+			Usage:       "Libp2p TCP listening port for secure websocket connection (0 for random, binding to 443 requires root access)",
+			Destination: &options.Websocket.WSSPort,
 		},
 		&cli.StringFlag{
 			Name:        "websocket-address",

--- a/waku/options.go
+++ b/waku/options.go
@@ -138,7 +138,8 @@ type RESTServerOptions struct {
 // support
 type WSOptions struct {
 	Enable   bool
-	Port     int
+	WSPort   int
+	WSSPort  int
 	Address  string
 	Secure   bool
 	KeyPath  string

--- a/waku/v2/node/wakuoptions.go
+++ b/waku/v2/node/wakuoptions.go
@@ -121,6 +121,11 @@ func (w WakuNodeParameters) Identity() config.Option {
 	return libp2p.Identity(*w.GetPrivKey())
 }
 
+// TLSConfig returns the TLS config used for setting up secure websockets
+func (w WakuNodeParameters) TLSConfig() *tls.Config {
+	return w.tlsConfig
+}
+
 // AddressFactory returns the address factory used by the node's host
 func (w WakuNodeParameters) AddressFactory() basichost.AddrsFactory {
 	return w.addressFactory


### PR DESCRIPTION
Fixes #275 
Adds the flag `--websocket-secure-port` and its alias `--wss-port` to allow setting up different ports for websockets and secure websockets.