### PR TITLE
Dockerfile: update to GO 1.18, update Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # BUILD IMAGE --------------------------------------------------------
-FROM golang:1.17-alpine as builder
+FROM golang:1.18-alpine3.16 as builder
 
 # Get build tools and required header files
 RUN apk add --no-cache build-base
@@ -14,7 +14,7 @@ RUN make -j$(nproc) build
 
 # ACTUAL IMAGE -------------------------------------------------------
 
-FROM alpine:3.12
+FROM alpine:3.16
 
 ARG GIT_COMMIT=unknown
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/status-im/go-waku
 
-go 1.17
+go 1.18
 
 replace github.com/ethereum/go-ethereum v1.10.25 => github.com/status-im/go-ethereum v1.10.4-status.2
 


### PR DESCRIPTION
Otherwise we get build errors like:
```
note: module requires Go 1.18
```
https://ci.infra.status.im/job/go-waku/job/deploy-test/28/